### PR TITLE
Add multilingual GUI with language persistence

### DIFF
--- a/index.html
+++ b/index.html
@@ -46,6 +46,9 @@
             border: 1px solid var(--border-color); border-radius: 4px;
         }
         select { cursor: pointer; width: 90%; max-width: 618px; }
+        .language-select { text-align: right; margin-bottom: 10px; }
+        .language-select label { display: inline-block; margin-right: 5px; font-weight: bold; }
+        .language-select select { width: auto; }
         button {
             padding: 10px 15px; cursor: pointer; margin-top: 10px;
             background: var(--primary); color: #fff; border: none;
@@ -321,11 +324,19 @@
         <a href="https://www.arkons.ch/" target="_blank">https://www.arkons.ch/</a>,
         2025
     </div>
+    <div class="language-select">
+        <label id="langLabel" for="languageSelect">Sprache:</label>
+        <select id="languageSelect">
+            <option value="de">Deutsch</option>
+            <option value="fr">Français</option>
+            <option value="it">Italiano</option>
+        </select>
+    </div>
 
-    <h1>Neuer Arzttarif Schweiz: TARDOC und Pauschalen</h1>
-    <p>Geben Sie die medizinische Leistung oder die LKN ein (inkl. relevanter Details wie Dauer, Alter, Geschlecht, falls zutreffend). Der Assistent prüft die optimale Abrechnung.</p>
+    <h1 id="mainHeader">Neuer Arzttarif Schweiz: TARDOC und Pauschalen</h1>
+    <p id="intro">Geben Sie die medizinische Leistung oder die LKN ein (inkl. relevanter Details wie Dauer, Alter, Geschlecht, falls zutreffend). Der Assistent prüft die optimale Abrechnung.</p>
 
-    <label for="beispielSelect">Beispiele auswählen:</label>
+    <label id="exampleLabel" for="beispielSelect">Beispiele auswählen:</label>
     <select id="beispielSelect" onchange="beispielEinfuegen()">
         <option value="" selected disabled>--- Bitte wählen ---</option>
         <option value="Hausärztliche Konsultation von 17 Minuten">Hausärztliche Konsultation 17 Min.</option>
@@ -342,18 +353,18 @@
         <option value="Bronchoskopie mit Lavage">Bronchoskopie mit Lavage</option>
     </select>
 
-    <label for="userInput">Leistungsbeschreibung / LKN:</label>
+    <label id="userLabel" for="userInput">Leistungsbeschreibung / LKN:</label>
     <textarea id="userInput" rows="4" placeholder="z.B. Hausärztliche Konsultation von 17 Minuten..."></textarea>
 
-    <label for="icdInput">Zusätzliche ICD-Codes (kommagetrennt, optional):</label>
+    <label id="icdLabel" for="icdInput">Zusätzliche ICD-Codes (kommagetrennt, optional):</label>
     <input type="text" id="icdInput" placeholder="z.B. K35.8, J45.9">
-    <label for="gtinInput">Medikamenten-GTINs (kommagetrennt, optional):</label>
+    <label id="gtinLabel" for="gtinInput">Medikamenten-GTINs (kommagetrennt, optional):</label>
     <input type="text" id="gtinInput" placeholder="z.B. 7680664950014, 1234567890123">
 
     <div style="display: flex; flex-wrap: wrap; gap: 20px; margin-top: 15px; margin-bottom: 15px; max-width: 630px;">
         <div style="align-self: center;">
             <input type="checkbox" id="useIcdCheckbox" checked style="margin-right: 5px;">
-            <label for="useIcdCheckbox" style="display: inline; font-weight: normal;">ICD berücksichtigen</label>
+            <label id="useIcdLabel" for="useIcdCheckbox" style="display: inline; font-weight: normal;">ICD berücksichtigen</label>
         </div>
     </div>
 
@@ -361,28 +372,127 @@
     <div id="spinner">Wird geladen...</div>
     <div id="output">Hier erscheinen die Ergebnisse...</div>
 
-    <div class="disclaimer">
+    <div class="disclaimer" id="disclaimer">
         <strong>Haftungsausschluss:</strong> Alle Auskünfte erfolgen ohne Gewähr... (<a href="https://tarifbrowser.oaat-otma.ch/startPortal" target="_blank">TARDOC Online-Portal</a>).
     </div>
 
     <script src="calculator.js"></script>
     <script>
-        function beispielEinfuegen() {
-            const selectElement = document.getElementById('beispielSelect');
-            const selectedValue = selectElement.value;
-            const targetTextarea = document.getElementById('userInput');
-            if (selectedValue && targetTextarea) {
-                targetTextarea.value = selectedValue;
-                const outputDiv = document.getElementById('output');
-                if (outputDiv) outputDiv.innerHTML = "<i>Bitte 'Tarifpositionen finden' klicken.</i>";
+        const translations = {
+            de: {
+                langLabel: 'Sprache:',
+                title: 'TARDOC / Pauschalen Rechner Prototyp',
+                header: 'Neuer Arzttarif Schweiz: TARDOC und Pauschalen',
+                intro: 'Geben Sie die medizinische Leistung oder die LKN ein (inkl. relevanter Details wie Dauer, Alter, Geschlecht, falls zutreffend). Der Assistent prüft die optimale Abrechnung.',
+                exampleLabel: 'Beispiele auswählen:',
+                examples: ['--- Bitte wählen ---','Hausärztliche Konsultation 17 Min.','Konsultation 10 Min + Warzenentfernung Stamm','Konsultation 25 Min, rheumatol. Untersuch','Konsultation 15 Minuten','hausärztliche Konsultation 25 Minuten','Hausärztliche Kons 15 Min + 10 Min. Beratung Kind','Kiefergelenk, Luxation, Reposition','Kiefergelenk, Luxation, Reposition, Anästhesie','Aufklärung + Leberbiopsie (Haut)','Blinddarmentfernung (alleinig)','Korrektur Hallux valgus rechts','Bronchoskopie mit Lavage'],
+                exampleValues: ['', 'Hausärztliche Konsultation von 17 Minuten','Konsultation 10 Minuten und Entfernung Warze mit scharfem Löffel 5 Minuten, mit Wechselzeit zu Dermatologie','Konsultation 25 Minuten, grosser rheumatologischer Untersuch','Konsultation 15 Minuten','Konsultation 25 Minuten Hausarzt','Hausärztliche Konsultation 15 Minuten und 10 Minuten Beratung Kind','Kiefergelenk, Luxation. Geschlossene Reposition','Kiefergelenk, Luxation. Geschlossene Reposition mit Anästhesie durch Anästhesist','Aufklärung des Patienten und Leberbiopsie durch die Haut','Blinddarmentfernung als alleinige Leistung','Korrektur eines Hallux valgus rechts','Bronchoskopie mit Lavage'],
+                userLabel: 'Leistungsbeschreibung / LKN:',
+                userPlaceholder: 'z.B. Hausärztliche Konsultation von 17 Minuten...',
+                icdLabel: 'Zusätzliche ICD-Codes (kommagetrennt, optional):',
+                icdPlaceholder: 'z.B. K35.8, J45.9',
+                gtinLabel: 'Medikamenten-GTINs (kommagetrennt, optional):',
+                gtinPlaceholder: 'z.B. 7680664950014, 1234567890123',
+                useIcd: 'ICD berücksichtigen',
+                analyzeButton: 'Tarifpositionen finden',
+                loading: 'Wird geladen...',
+                resultsPlaceholder: 'Hier erscheinen die Ergebnisse...',
+                disclaimer: '<strong>Haftungsausschluss:</strong> Alle Auskünfte erfolgen ohne Gewähr... (<a href="https://tarifbrowser.oaat-otma.ch/startPortal" target="_blank">TARDOC Online-Portal</a>).',
+                clickFind: "<i>Bitte 'Tarifpositionen finden' klicken.</i>"
+            },
+            fr: {
+                langLabel: 'Langue :',
+                title: 'Prototype du calculateur de forfaits / TARDOC',
+                header: 'Nouveau tarif médical suisse : TARDOC et forfaits',
+                intro: "Saisissez la prestation médicale ou le NPL (y compris les détails pertinents tels que durée, âge, sexe, le cas échéant). L'assistant vérifie la facturation optimale.",
+                exampleLabel: 'Sélectionner un exemple :',
+                examples: ['--- Veuillez choisir ---','Consultation de médecine de famille de 17 minutes','Consultation de 10 min et ablation d\'une verrue par curette 5 min, avec passage en dermatologie','Consultation de 25 minutes, grand examen rhumatologique','Consultation de 15 minutes','Consultation de médecine de famille de 25 minutes','Consultation de MF 15 min + 10 min conseil enfant','Articulation temporo-mandibulaire, luxation, réduction','Articulation temporo-mandibulaire, luxation, réduction, anesthésie','Explication au patient et biopsie hépatique transcutanée','Appendicectomie comme acte isolé','Correction d\'un hallux valgus droit','Bronchoscopie avec lavage'],
+                exampleValues: ['', 'Consultation de médecine de famille de 17 minutes','Consultation de 10 minutes et ablation d\'une verrue avec curette 5 minutes, avec passage en dermatologie','Consultation de 25 minutes, grand examen rhumatologique','Consultation de 15 minutes','Consultation de médecine de famille de 25 minutes','Consultation de MF 15 minutes + 10 minutes conseil enfant','Articulation temporo-mandibulaire, luxation, réduction','Articulation temporo-mandibulaire, luxation, réduction, anesthésie','Explication au patient et biopsie hépatique transcutanée','Appendicectomie comme acte isolé','Correction d\'un hallux valgus droit','Bronchoscopie avec lavage'],
+                userLabel: 'Description de la prestation / NPL :',
+                userPlaceholder: 'p. ex. consultation de médecine de famille de 17 minutes...',
+                icdLabel: 'Codes CIM supplémentaires (séparés par des virgules, optionnel) :',
+                icdPlaceholder: 'p. ex. K35.8, J45.9',
+                gtinLabel: 'GTIN des médicaments (séparées par des virgules, optionnel) :',
+                gtinPlaceholder: 'p. ex. 7680664950014, 1234567890123',
+                useIcd: 'Prendre en compte la CIM',
+                analyzeButton: 'Trouver les positions tarifaires',
+                loading: 'Chargement...',
+                resultsPlaceholder: "Les résultats s'affichent ici...",
+                disclaimer: '<strong>Clause de non-responsabilité :</strong> Toutes les informations sont fournies sans garantie... (<a href="https://tarifbrowser.oaat-otma.ch/startPortal" target="_blank">Portail en ligne TARDOC</a>).',
+                clickFind: "<i>Veuillez cliquer sur 'Trouver les positions tarifaires'.</i>"
+            },
+            it: {
+                langLabel: 'Lingua:',
+                title: 'Prototipo calcolatore di forfait / TARDOC',
+                header: 'Nuova tariffa medica svizzera: TARDOC e forfait',
+                intro: "Inserisci la prestazione medica o il NPL (compresi i dettagli rilevanti come durata, età, sesso, se applicabile). L'assistente verifica la fatturazione ottimale.",
+                exampleLabel: 'Seleziona un esempio:',
+                examples: ['--- Seleziona ---','Consultazione di base di 17 minuti','Consultazione di 10 minuti e rimozione di una verruca con cucchiaio affilato 5 minuti, con passaggio a dermatologia','Consultazione di 25 minuti, grande esame reumatologico','Consultazione di 15 minuti','Consultazione di base di 25 minuti','Consultazione MF 15 min + 10 min consulenza bambino','Articolazione temporo-mandibolare, lussazione, riduzione','Articolazione temporo-mandibolare, lussazione, riduzione, anestesia','Spiegazione al paziente e biopsia epatica percutanea','Appendicectomia come prestazione singola','Correzione di alluce valgo destro','Broncoscopia con lavaggio'],
+                exampleValues: ['', 'Consultazione di base di 17 minuti','Consultazione di 10 minuti e rimozione di una verruca con cucchiaio affilato 5 minuti, con passaggio a dermatologia','Consultazione di 25 minuti, grande esame reumatologico','Consultazione di 15 minuti','Consultazione di base di 25 minuti','Consultazione MF 15 min + 10 min consulenza bambino','Articolazione temporo-mandibolare, lussazione, riduzione','Articolazione temporo-mandibolare, lussazione, riduzione, anestesia','Spiegazione al paziente e biopsia epatica percutanea','Appendicectomia come prestazione singola','Correzione di alluce valgo destro','Broncoscopia con lavaggio'],
+                userLabel: 'Descrizione della prestazione / NPL:',
+                userPlaceholder: 'es. consultazione di base di 17 minuti...',
+                icdLabel: 'Codici ICD aggiuntivi (separati da virgole, opzionale):',
+                icdPlaceholder: 'es. K35.8, J45.9',
+                gtinLabel: 'GTIN dei medicamenti (separate da virgole, opzionale):',
+                gtinPlaceholder: 'es. 7680664950014, 1234567890123',
+                useIcd: 'Considera ICD',
+                analyzeButton: 'Trova le posizioni tariffarie',
+                loading: 'Caricamento...',
+                resultsPlaceholder: 'Qui verranno visualizzati i risultati...',
+                disclaimer: '<strong>Clausola di esclusione della responsabilità:</strong> tutte le informazioni sono fornite senza garanzia... (<a href="https://tarifbrowser.oaat-otma.ch/startPortal" target="_blank">Portale online TARDOC</a>).',
+                clickFind: "<i>Fare clic su 'Trova le posizioni tariffarie'.</i>"
+            }
+        };
+        let currentLang = 'de';
+        function applyLanguage(lang){
+            currentLang = lang;
+            localStorage.setItem('language', lang);
+            document.documentElement.lang = lang;
+            const t = translations[lang];
+            document.getElementById('langLabel').textContent = t.langLabel;
+            document.title = t.title;
+            document.getElementById('mainHeader').textContent = t.header;
+            document.getElementById('intro').textContent = t.intro;
+            document.getElementById('exampleLabel').textContent = t.exampleLabel;
+            const opts = document.querySelectorAll('#beispielSelect option');
+            t.examples.forEach((text,i)=>{ if(opts[i]){opts[i].textContent=text; opts[i].value=t.exampleValues[i];}});
+            document.getElementById('userLabel').textContent = t.userLabel;
+            document.getElementById('userInput').placeholder = t.userPlaceholder;
+            document.getElementById('icdLabel').textContent = t.icdLabel;
+            document.getElementById('icdInput').placeholder = t.icdPlaceholder;
+            document.getElementById('gtinLabel').textContent = t.gtinLabel;
+            document.getElementById('gtinInput').placeholder = t.gtinPlaceholder;
+            document.getElementById('useIcdLabel').textContent = t.useIcd;
+            document.getElementById('analyzeButton').textContent = t.analyzeButton;
+            document.getElementById('spinner').textContent = t.loading;
+            const out = document.getElementById('output');
+            if(out && !out.innerHTML.trim()) out.textContent = t.resultsPlaceholder;
+            document.getElementById('disclaimer').innerHTML = t.disclaimer;
+        }
+        function beispielEinfuegen(){
+            const sel=document.getElementById('beispielSelect');
+            const val=sel.value;
+            const ta=document.getElementById('userInput');
+            if(val && ta){
+                ta.value=val;
+                const out=document.getElementById('output');
+                if(out) out.innerHTML=translations[currentLang].clickFind;
             }
         }
-        document.addEventListener('DOMContentLoaded', () => {
-            const outputDiv = document.getElementById('output');
-            if (outputDiv) outputDiv.innerHTML = "";
-            const selectElement = document.getElementById('beispielSelect');
-            if(selectElement) selectElement.selectedIndex = 0;
-        });
+        function initLanguage(){
+            const stored=localStorage.getItem('language');
+            let lang=stored||navigator.language.slice(0,2).toLowerCase();
+            if(!['de','fr','it'].includes(lang)) lang='de';
+            const sel=document.getElementById('languageSelect');
+            if(sel) sel.value=lang;
+            applyLanguage(lang);
+            const out=document.getElementById('output');
+            if(out) out.innerHTML='';
+            const selB=document.getElementById('beispielSelect');
+            if(selB) selB.selectedIndex=0;
+        }
+        document.getElementById('languageSelect').addEventListener('change',e=>applyLanguage(e.target.value));
+        document.addEventListener('DOMContentLoaded',initLanguage);
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- support German, French and Italian texts in `index.html`
- detect system language or stored selection and apply automatically
- add selector to change language; saves choice in local storage
- translate placeholders, labels and example data

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6850198fa4b083238c81dead08dc4157