### PR TITLE
Enable multi-language data output

### DIFF
--- a/regelpruefer.py
+++ b/regelpruefer.py
@@ -6,7 +6,8 @@ und der Bedingungen für Pauschalen.
 """
 import json
 import re # Importiere Regex für Mengenanpassung
-from typing import Dict, List 
+from typing import Dict, List
+from utils import get_lang_field
 
 # --- Konstanten für Regeltypen (zur besseren Lesbarkeit) ---
 REGEL_MENGE = "Mengenbeschränkung"
@@ -184,7 +185,8 @@ def pruefe_abrechnungsfaehigkeit(fall: dict, regelwerk: dict) -> dict:
 
     return {"abrechnungsfaehig": allowed, "fehler": errors}
 
-def prepare_tardoc_abrechnung(regel_ergebnisse_liste: list[dict], leistungskatalog_dict: dict) -> dict: # Argument hinzugefügt
+
+def prepare_tardoc_abrechnung(regel_ergebnisse_liste: list[dict], leistungskatalog_dict: dict, lang: str = 'de') -> dict:
     """
     Filtert regelkonforme TARDOC-Leistungen (Typ E/EZ) aus den Regelergebnissen
     und bereitet die Liste für die Frontend-Antwort vor.
@@ -205,9 +207,10 @@ def prepare_tardoc_abrechnung(regel_ergebnisse_liste: list[dict], leistungskatal
 
         if lkn_info and lkn_info.get("Typ") in ['E', 'EZ']:
             tardoc_leistungen_final.append({
-                "lkn": lkn, "menge": menge,
+                "lkn": lkn,
+                "menge": menge,
                 "typ": lkn_info.get("Typ"),
-                "beschreibung": lkn_info.get("Beschreibung", "")
+                "beschreibung": get_lang_field(lkn_info, "Beschreibung", lang) or ""
             })
         elif not lkn_info:
              print(f"WARNUNG (prepare_tardoc): Details für LKN {lkn} nicht im Leistungskatalog gefunden.")

--- a/utils.py
+++ b/utils.py
@@ -31,3 +31,10 @@ def get_table_content(table_ref: str, table_type: str, tabellen_dict_by_table: d
 
     unique_content = {item['Code']: item for item in all_entries_for_type}.values()
     return sorted(unique_content, key=lambda x: x.get('Code', ''))
+
+def get_lang_field(entry: Dict[str, Any], base_key: str, lang: str) -> Any:
+    """Returns the value for a language-aware key if available."""
+    if not isinstance(entry, dict):
+        return None
+    suffix = {'de': '', 'fr': '_f', 'it': '_i'}.get(str(lang).lower(), '')
+    return entry.get(f"{base_key}{suffix}") or entry.get(base_key)


### PR DESCRIPTION
## Summary
- implement `get_lang_field` helper for localized text
- add language support in server API and processing
- update regelpruefer modules to use selected language
- extend frontend JS to request and display localized fields

## Testing
- `python -m py_compile server.py regelpruefer.py regelpruefer_pauschale.py utils.py`

------
https://chatgpt.com/codex/tasks/task_e_68503be19bc08323bb0d86f0b14cebb0