### PR TITLE
Fix example dropdown values

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -539,6 +539,10 @@ document.addEventListener("DOMContentLoaded", () => {
 async function getBillingAnalysis() {
     console.log("[getBillingAnalysis] Funktion gestartet.");
     const userInput = $("userInput").value.trim();
+    let mappedInput = userInput;
+    if(exampleValueToDe[currentLang] && exampleValueToDe[currentLang][userInput]){
+        mappedInput = exampleValueToDe[currentLang][userInput];
+    }
     const icdInput = $("icdInput").value.trim().split(",").map(s => s.trim().toUpperCase()).filter(Boolean);
     const gtinInput = ($("gtinInput") ? $("gtinInput").value.trim().split(",").map(s => s.trim()).filter(Boolean) : []);
     const useIcd = $('useIcdCheckbox')?.checked ?? true;
@@ -561,7 +565,7 @@ async function getBillingAnalysis() {
     try {
         console.log("[getBillingAnalysis] Sende Anfrage an Backend...");
         const requestBody = {
-            inputText: userInput,
+            inputText: mappedInput,
             icd: icdInput,
             gtin: gtinInput,
             useIcd: useIcd,

--- a/index.html
+++ b/index.html
@@ -453,6 +453,36 @@
                 clickFind: "<i>Fare clic su 'Trova le posizioni tariffarie'.</i>"
             }
         };
+        const exampleValueToDe = {
+            fr: {
+                'Consultation de médecine de famille de 17 minutes': 'Hausärztliche Konsultation von 17 Minuten',
+                "Consultation de 10 min et ablation d'une verrue par curette 5 min, avec passage en dermatologie": 'Konsultation 10 Minuten und Entfernung Warze mit scharfem Löffel 5 Minuten, mit Wechselzeit zu Dermatologie',
+                'Consultation de 25 minutes, grand examen rhumatologique': 'Konsultation 25 Minuten, grosser rheumatologischer Untersuch',
+                'Consultation de 15 minutes': 'Konsultation 15 Minuten',
+                'Consultation de médecine de famille de 25 minutes': 'Konsultation 25 Minuten Hausarzt',
+                'Consultation de MF 15 min + 10 min conseil enfant': 'Hausärztliche Konsultation 15 Minuten und 10 Minuten Beratung Kind',
+                'Articulation temporo-mandibulaire, luxation, réduction': 'Kiefergelenk, Luxation. Geschlossene Reposition',
+                'Articulation temporo-mandibulaire, luxation, réduction, anesthésie': 'Kiefergelenk, Luxation. Geschlossene Reposition mit Anästhesie durch Anästhesist',
+                'Explication au patient et biopsie hépatique transcutanée': 'Aufklärung des Patienten und Leberbiopsie durch die Haut',
+                'Appendicectomie comme acte isolé': 'Blinddarmentfernung als alleinige Leistung',
+                "Correction d'un hallux valgus droit": 'Korrektur eines Hallux valgus rechts',
+                'Bronchoscopie avec lavage': 'Bronchoskopie mit Lavage'
+            },
+            it: {
+                'Consultazione di base di 17 minuti': 'Hausärztliche Konsultation von 17 Minuten',
+                'Consultazione di 10 minuti e rimozione di una verruca con cucchiaio affilato 5 minuti, con passaggio a dermatologia': 'Konsultation 10 Minuten und Entfernung Warze mit scharfem Löffel 5 Minuten, mit Wechselzeit zu Dermatologie',
+                'Consultazione di 25 minuti, grande esame reumatologico': 'Konsultation 25 Minuten, grosser rheumatologischer Untersuch',
+                'Consultazione di 15 minuti': 'Konsultation 15 Minuten',
+                'Consultazione di base di 25 minuti': 'Konsultation 25 Minuten Hausarzt',
+                'Consultazione MF 15 min + 10 min consulenza bambino': 'Hausärztliche Konsultation 15 Minuten und 10 Minuten Beratung Kind',
+                'Articolazione temporo-mandibolare, lussazione, riduzione': 'Kiefergelenk, Luxation. Geschlossene Reposition',
+                'Articolazione temporo-mandibolare, lussazione, riduzione, anestesia': 'Kiefergelenk, Luxation. Geschlossene Reposition mit Anästhesie durch Anästhesist',
+                'Spiegazione al paziente e biopsia epatica percutanea': 'Aufklärung des Patienten und Leberbiopsie durch die Haut',
+                'Appendicectomia come prestazione singola': 'Blinddarmentfernung als alleinige Leistung',
+                'Correzione di alluce valgo destro': 'Korrektur eines Hallux valgus rechts',
+                'Broncoscopia con lavaggio': 'Bronchoskopie mit Lavage'
+            }
+        };
         let currentLang = 'de';
         function applyLanguage(lang){
             const prevLang = currentLang;


### PR DESCRIPTION
## Summary
- restore German example dropdown values
- map FR/IT examples to German only for backend requests

## Testing
- `python -m py_compile server.py regelpruefer.py regelpruefer_pauschale.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68506384decc8323b07cf988a44214e3