### PR TITLE
Show TARDOC interpretation in rule section

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -300,7 +300,7 @@ function buildLknInfoHtmlFromCode(code) {
 function getInterpretation(code) {
     if (!interpretationMap) return '';
     const entry = interpretationMap[code] || interpretationMap[code.split('.')[0]];
-    return entry ? entry.Interpretation || '' : '';
+    return entry ? getLangField(entry, 'Interpretation') || '' : '';
 }
 
 function getChapterInfo(kapitelCode) {
@@ -939,6 +939,11 @@ function displayTardocTable(tardocLeistungen, ruleResultsDetailsList = []) {
         const al = tardocDetails.al;
         const ipl = tardocDetails.ipl;
         let regelnHtml = tardocDetails.regeln ? `<p><b>TARDOC-Regel:</b> ${tardocDetails.regeln}</p>` : '';
+        const interpretationText = getInterpretation(String(lkn));
+        if (interpretationText) {
+            if (regelnHtml) regelnHtml += "<hr style='margin: 5px 0; border-color: #eee;'>";
+            regelnHtml += `<p><b>Interpretation:</b> ${escapeHtml(interpretationText)}</p>`;
+        }
 
         const ruleResult = ruleResultsDetailsList.find(r => r.lkn === lkn);
         let hasHintForThisLKN = false;


### PR DESCRIPTION
## Summary
- show language-specific interpretation text from `TARDOC_Interpretationen.json`
- expose the interpretation in the rules/hints column

## Testing
- `node --check calculator.js`


------
https://chatgpt.com/codex/tasks/task_e_6852f9445c4483238315e44e32d88de0