### PR TITLE
Add diagnosis translations

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -1082,7 +1082,7 @@ function displayTardocTable(tardocLeistungen, ruleResultsDetailsList = []) {
         let hasHintForThisLKN = false;
         if (ruleResult && ruleResult.regelpruefung && ruleResult.regelpruefung.fehler && ruleResult.regelpruefung.fehler.length > 0) {
              if (regelnHtml) regelnHtml += "<hr style='margin: 5px 0; border-color: #eee;'>";
-             regelnHtml += `<p><b>Hinweise Backend-Regelprüfung:</b></p><ul>`;
+             regelnHtml += `<p><b>${tDyn('ruleHints')}</b></p><ul>`;
              ruleResult.regelpruefung.fehler.forEach(hinweis => {
                   const isReduction = hinweis.includes("Menge auf");
                   const style = isReduction ? "color: var(--danger); font-weight: bold;" : "";

--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -2,7 +2,7 @@
 import traceback
 import json
 from typing import Dict, List, Any, Set # <-- Set hier importieren
-from utils import escape, get_table_content, get_lang_field
+from utils import escape, get_table_content, get_lang_field, translate, translate_condition_type
 import re, html
 
 # === FUNKTION ZUR PRÜFUNG EINER EINZELNEN BEDINGUNG ===
@@ -150,11 +150,16 @@ def get_beschreibung_fuer_lkn_im_backend(lkn_code: str, leistungskatalog_dict: D
         return lkn_code
     return get_lang_field(details, 'Beschreibung', lang) or lkn_code
 
-def get_beschreibung_fuer_icd_im_backend(icd_code: str, tabellen_dict_by_table: Dict, spezifische_icd_tabelle: str | None = None) -> str:
+def get_beschreibung_fuer_icd_im_backend(
+    icd_code: str,
+    tabellen_dict_by_table: Dict,
+    spezifische_icd_tabelle: str | None = None,
+    lang: str = 'de'
+) -> str:
+    """Liefert die Beschreibung eines ICD-Codes in der gewünschten Sprache."""
     # Wenn eine spezifische Tabelle bekannt ist (z.B. aus der Bedingung), diese zuerst prüfen
     if spezifische_icd_tabelle:
-        # print(f"DEBUG: Suche ICD {icd_code} in spezifischer Tabelle {spezifische_icd_tabelle}")
-        icd_entries_specific = get_table_content(spezifische_icd_tabelle, "icd", tabellen_dict_by_table)
+        icd_entries_specific = get_table_content(spezifische_icd_tabelle, "icd", tabellen_dict_by_table, lang)
         for entry in icd_entries_specific:
             if entry.get('Code', '').upper() == icd_code.upper():
                 return entry.get('Code_Text', icd_code)
@@ -163,7 +168,7 @@ def get_beschreibung_fuer_icd_im_backend(icd_code: str, tabellen_dict_by_table: 
     # Du müsstest den Namen deiner Haupt-ICD-Tabelle hier eintragen, z.B. "icd10gm_codes"
     haupt_icd_tabelle_name = "icd_hauptkatalog" # Beispielname, anpassen!
     # print(f"DEBUG: Suche ICD {icd_code} in Haupttabelle {haupt_icd_tabelle_name}")
-    icd_entries_main = get_table_content(haupt_icd_tabelle_name, "icd", tabellen_dict_by_table)
+    icd_entries_main = get_table_content(haupt_icd_tabelle_name, "icd", tabellen_dict_by_table, lang)
     for entry in icd_entries_main:
         if entry.get('Code', '').upper() == icd_code.upper():
             return entry.get('Code_Text', icd_code)
@@ -297,7 +302,8 @@ def check_pauschale_conditions(
         
         li_content = f"<div data-bedingung-id='{escape(str(bedingung_id))}' class='condition-item-row'>"
         li_content += icon_html
-        li_content += f"<span class='condition-type-display'>({escape(bedingungstyp)}):</span> "
+        translated_type = translate_condition_type(bedingungstyp, lang)
+        li_content += f"<span class='condition-type-display'>({escape(translated_type)}):</span> "
         
         specific_description_html = ""
         is_lkn_condition_type = False # Für trigger_lkn_condition_met (obwohl das hier nicht mehr direkt gesetzt wird)
@@ -319,23 +325,27 @@ def check_pauschale_conditions(
                 type_prefix = "ICD"; type_for_get_table_content = "icd"
                 kontext_elemente_fuer_vergleich = provided_icds_im_kontext_upper
             
-            specific_description_html += f"Erfordert {type_prefix} aus Tabelle(n): "
-            if not table_names_list: specific_description_html += "<i>Kein Tabellenname spezifiziert.</i>"
+            specific_description_html += translate('require_lkn_table' if type_prefix == 'LKN' else 'require_icd_table', lang)
+            if not table_names_list: specific_description_html += f"<i>{translate('no_table_name', lang)}</i>"
             else:
                 table_links_html_parts = []
                 all_codes_in_regel_tabellen = set() 
                 for table_name in table_names_list:
-                    table_content_entries = get_table_content(table_name, type_for_get_table_content, tabellen_dict_by_table)
+                    table_content_entries = get_table_content(table_name, type_for_get_table_content, tabellen_dict_by_table, lang)
                     entry_count = len(table_content_entries); details_content_html = ""
                     current_table_codes_with_desc = {}
                     if table_content_entries:
                         details_content_html = "<ul style='margin-top: 5px; font-size: 0.9em; max-height: 150px; overflow-y: auto; border-top: 1px solid #eee; padding-top: 5px; padding-left: 15px; list-style-position: inside;'>"
                         for item in sorted(table_content_entries, key=lambda x: x.get('Code', '')):
                             item_code = item.get('Code','').upper(); all_codes_in_regel_tabellen.add(item_code)
-                            item_text = item.get('Code_Text', 'N/A'); current_table_codes_with_desc[item_code] = item_text
+                            item_text = item.get('Code_Text', 'N/A')
+                            if type_prefix == "LKN":
+                                item_text = get_beschreibung_fuer_lkn_im_backend(item_code, leistungskatalog_dict, lang)
+                            current_table_codes_with_desc[item_code] = item_text
                             details_content_html += f"<li><b>{escape(item_code)}</b>: {escape(item_text)}</li>"
                         details_content_html += "</ul>"
-                    table_detail_html = (f"<details><summary>{escape(table_name)}</summary> ({entry_count} Einträge){details_content_html}</details>")
+                    entries_label = translate('entries_label', lang)
+                    table_detail_html = (f"<details><summary>{escape(table_name)}</summary> ({entry_count} {entries_label}){details_content_html}</details>")
                     table_links_html_parts.append(table_detail_html)
                     # Finde erfüllende Elemente für diese spezifische Tabelle
                     for kontext_code in kontext_elemente_fuer_vergleich:
@@ -344,21 +354,41 @@ def check_pauschale_conditions(
                 
                 specific_description_html += ", ".join(table_links_html_parts)
                 if condition_met_this_line and erfuellende_element_beschreibungen_aus_tabellen:
-                    details_list = [f"<b>{escape(code)}</b> ({escape(desc)})" for code, desc in erfuellende_element_beschreibungen_aus_tabellen.items() if code in kontext_elemente_fuer_vergleich] # Nur die aus dem Kontext
-                    if details_list: kontext_erfuellungs_info_html = f" <span class='context-match-info fulfilled'>(Erfüllt durch: {', '.join(details_list)})</span>"
+                    details_list = [f"<b>{escape(code)}</b> ({escape(desc)})" for code, desc in erfuellende_element_beschreibungen_aus_tabellen.items() if code in kontext_elemente_fuer_vergleich]
+                    if details_list:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info fulfilled'>"
+                            f"{translate('fulfilled_by', lang, items=', '.join(details_list))}"
+                            f"</span>"
+                        )
                 elif condition_met_this_line: # Erfüllt, aber keine Beschreibung gefunden (sollte nicht passieren, wenn Logik stimmt)
                     erfuellende_kontext_codes_ohne_desc = [k for k in kontext_elemente_fuer_vergleich if k in all_codes_in_regel_tabellen]
-                    if erfuellende_kontext_codes_ohne_desc: kontext_erfuellungs_info_html = f" <span class='context-match-info fulfilled'>(Erfüllt durch: {', '.join(escape(c) for c in erfuellende_kontext_codes_ohne_desc)})</span>"
+                    if erfuellende_kontext_codes_ohne_desc:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info fulfilled'>"
+                            f"{translate('fulfilled_by', lang, items=', '.join(escape(c) for c in erfuellende_kontext_codes_ohne_desc))}"
+                            f"</span>"
+                        )
                 elif not condition_met_this_line and all_codes_in_regel_tabellen : # Nicht erfüllt UND Regel-Tabelle hatte Codes
                     fehlende_elemente_details = []
                     # Zeige Kontext-Elemente, die NICHT in der Regel-Tabelle waren
                     for kontext_code in kontext_elemente_fuer_vergleich:
                         if kontext_code not in all_codes_in_regel_tabellen:
-                            desc = get_beschreibung_fuer_lkn_im_backend(kontext_code, leistungskatalog_dict, lang) if type_prefix == "LKN" else get_beschreibung_fuer_icd_im_backend(kontext_code, tabellen_dict_by_table, spezifische_icd_tabelle=aktuelle_tabelle_fuer_icd_fallback if aktuelle_tabelle_fuer_icd_fallback is not None else None)
+                            desc = get_beschreibung_fuer_lkn_im_backend(kontext_code, leistungskatalog_dict, lang) if type_prefix == "LKN" else get_beschreibung_fuer_icd_im_backend(
+                                kontext_code,
+                                tabellen_dict_by_table,
+                                spezifische_icd_tabelle=aktuelle_tabelle_fuer_icd_fallback if aktuelle_tabelle_fuer_icd_fallback is not None else None,
+                                lang=lang,
+                            )
                             fehlende_elemente_details.append(f"<b>{escape(kontext_code)}</b> ({escape(desc)})")
-                    if fehlende_elemente_details : kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>(Kontext-Element(e) {', '.join(fehlende_elemente_details)} nicht in Regel-Tabelle(n) gefunden)</span>"
+                    if fehlende_elemente_details:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info not-fulfilled'>"
+                            f"{translate('context_items_not_in_table', lang, items=', '.join(fehlende_elemente_details))}"
+                            f"</span>"
+                        )
                 elif not condition_met_this_line and not all_codes_in_regel_tabellen: # Nicht erfüllt und Regel-Tabelle war leer
-                     kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>(Regel-Tabelle(n) leer oder nicht gefunden)</span>"
+                     kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>{translate('tables_empty', lang)}</span>"
 
 
         elif "IN LISTE" in bedingungstyp:
@@ -372,48 +402,76 @@ def check_pauschale_conditions(
             elif "GESCHLECHT" in bedingungstyp: # Speziell für GESCHLECHT IN LISTE
                 type_prefix = "Geschlecht"; kontext_elemente_fuer_vergleich = {str(context.get('Geschlecht', 'N/A')).lower()}
                 regel_items_lower_geschlecht = {item.strip().lower() for item in items_in_list_str.split(',') if item.strip()} # Regel-Items für Geschlecht auch lower
-                specific_description_html += f"Erfordert {type_prefix} aus Liste: "
-                if not regel_items_lower_geschlecht: specific_description_html += "<i>Keine Elemente spezifiziert.</i>"
+                specific_description_html += translate('geschlecht_list', lang)
+                if not regel_items_lower_geschlecht: specific_description_html += f"<i>{translate('no_gender_spec', lang)}</i>"
                 else: specific_description_html += f"{escape(', '.join(sorted(list(regel_items_lower_geschlecht))))}"
                 if condition_met_this_line:
                     erfuellendes_geschlecht = next((g for g in kontext_elemente_fuer_vergleich if g in regel_items_lower_geschlecht), None)
-                    if erfuellendes_geschlecht: kontext_erfuellungs_info_html = f" <span class='context-match-info fulfilled'>(Erfüllt durch: {escape(erfuellendes_geschlecht)})</span>"
+                    if erfuellendes_geschlecht:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info fulfilled'>"
+                            f"{translate('fulfilled_by', lang, items=escape(erfuellendes_geschlecht))}"
+                            f"</span>"
+                        )
                 # Keine "nicht erfüllt" Info hier, da es nur eine Liste ist.
             else: # Allgemeiner Fall für andere Listen (GTIN etc.)
-                specific_description_html += f"Erfordert {type_prefix} aus Liste: "
-                if not regel_items_upper: specific_description_html += "<i>Keine Elemente spezifiziert.</i>"
+                specific_description_html += translate('require_gtin_list' if type_prefix != 'Geschlecht' else 'geschlecht_list', lang)
+                if not regel_items_upper: specific_description_html += f"<i>{translate('no_gtins_spec' if type_prefix != 'Geschlecht' else 'no_gender_spec', lang)}</i>"
                 else: specific_description_html += f"{escape(', '.join(sorted(list(regel_items_upper))))}"
                 # Für GTIN etc. keine Beschreibung, nur Erfüllungsstatus
                 if condition_met_this_line:
                     erfuellende_items = [k for k in kontext_elemente_fuer_vergleich if k in regel_items_upper]
-                    if erfuellende_items: kontext_erfuellungs_info_html = f" <span class='context-match-info fulfilled'>(Erfüllt durch: {escape(', '.join(erfuellende_items))})</span>"
+                    if erfuellende_items:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info fulfilled'>"
+                            f"{translate('fulfilled_by', lang, items=escape(', '.join(erfuellende_items)))}"
+                            f"</span>"
+                        )
                 elif regel_items_upper: # Nicht erfüllt und Regel hatte Items
-                     kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>(Kein Kontext-Element in Regel-Liste)</span>"
+                     kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>{translate('no_context_in_list', lang)}</span>"
 
 
             # Dieser Block ist nur für LKN/ICD Listen, nicht für Geschlecht/GTIN
             if type_prefix in ["LKN", "ICD"]:
-                specific_description_html += f"Erfordert {type_prefix} aus Liste: "
-                if not regel_items_upper: specific_description_html += "<i>Keine Elemente spezifiziert.</i>"
+                specific_description_html += translate('require_lkn_list' if type_prefix in ['LKN','ICD'] else 'require_gtin_list', lang)
+                if not regel_items_upper: specific_description_html += f"<i>{translate('no_lkns_spec' if type_prefix in ['LKN','ICD'] else 'no_gtins_spec', lang)}</i>"
                 else: specific_description_html += f"{escape(', '.join(sorted(list(regel_items_upper))))}"
 
                 if condition_met_this_line:
                     erfuellende_details = []
                     for k_kontext in kontext_elemente_fuer_vergleich:
                         if k_kontext in regel_items_upper:
-                            desc = get_beschreibung_fuer_lkn_im_backend(k_kontext, leistungskatalog_dict, lang) if type_prefix == 'LKN' else get_beschreibung_fuer_icd_im_backend(k_kontext, tabellen_dict_by_table)
+                            desc = get_beschreibung_fuer_lkn_im_backend(k_kontext, leistungskatalog_dict, lang) if type_prefix == 'LKN' else get_beschreibung_fuer_icd_im_backend(
+                                k_kontext,
+                                tabellen_dict_by_table,
+                                lang=lang,
+                            )
                             erfuellende_details.append(f"<b>{escape(k_kontext)}</b> ({escape(desc)})")
-                    if erfuellende_details: kontext_erfuellungs_info_html = f" <span class='context-match-info fulfilled'>(Erfüllt durch: {', '.join(erfuellende_details)})</span>"
+                    if erfuellende_details:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info fulfilled'>"
+                            f"{translate('fulfilled_by', lang, items=', '.join(erfuellende_details))}"
+                            f"</span>"
+                        )
                 elif regel_items_upper : # Nicht erfüllt UND Regel-Liste hatte Items
                     fehlende_details = []
                     # Zeige Kontext-Elemente, die NICHT in der Regel-Liste waren
                     for k_kontext in kontext_elemente_fuer_vergleich:
                         if k_kontext not in regel_items_upper:
-                             desc = get_beschreibung_fuer_lkn_im_backend(k_kontext, leistungskatalog_dict, lang) if type_prefix == 'LKN' else get_beschreibung_fuer_icd_im_backend(k_kontext, tabellen_dict_by_table)
+                             desc = get_beschreibung_fuer_lkn_im_backend(k_kontext, leistungskatalog_dict, lang) if type_prefix == 'LKN' else get_beschreibung_fuer_icd_im_backend(
+                                 k_kontext,
+                                 tabellen_dict_by_table,
+                                 lang=lang,
+                             )
                              fehlende_details.append(f"<b>{escape(k_kontext)}</b> ({escape(desc)})")
-                    if fehlende_details: kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>(Kontext-Element(e) {', '.join(fehlende_details)} nicht in Regel-Liste)</span>"
+                    if fehlende_details:
+                        kontext_erfuellungs_info_html = (
+                            f" <span class='context-match-info not-fulfilled'>"
+                            f"{translate('context_items_not_in_list', lang, items=', '.join(fehlende_details))}"
+                            f"</span>"
+                        )
                 elif not regel_items_upper: # Nicht erfüllt und Regel-Liste war leer
-                     kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>(Regel-Liste leer)</span>"
+                     kontext_erfuellungs_info_html = f" <span class='context-match-info not-fulfilled'>{translate('rule_list_empty', lang)}</span>"
 
 
         elif bedingungstyp == "PATIENTENBEDINGUNG":
@@ -425,39 +483,64 @@ def check_pauschale_conditions(
                 if max_val_regel_html is not None: age_req_parts.append(f"max. {escape(str(max_val_regel_html))}")
                 if not age_req_parts and werte_aus_regel: age_req_parts.append(f"exakt {escape(werte_aus_regel)}")
                 specific_description_html += f", Anforderung: {(' und '.join(age_req_parts) or 'N/A')}"
-                kontext_erfuellungs_info_html = f" <span class='context-match-info { 'fulfilled' if condition_met_this_line else 'not-fulfilled' }'>(Kontext: {escape(str(context.get('Alter', 'N/A')))})</span>"
+                kontext_erfuellungs_info_html = (
+                    f" <span class='context-match-info {'fulfilled' if condition_met_this_line else 'not-fulfilled'}'>"
+                    f"{translate('context_value', lang, value=escape(str(context.get('Alter', 'N/A'))))}"
+                    f"</span>"
+                )
             elif feld_ref_patientenbed == "Geschlecht":
                 specific_description_html += f", Erwartet='{escape(werte_aus_regel)}'"
-                kontext_erfuellungs_info_html = f" <span class='context-match-info { 'fulfilled' if condition_met_this_line else 'not-fulfilled' }'>(Kontext: {escape(str(context.get('Geschlecht', 'N/A')))})</span>"
+                kontext_erfuellungs_info_html = (
+                    f" <span class='context-match-info {'fulfilled' if condition_met_this_line else 'not-fulfilled'}'>"
+                    f"{translate('context_value', lang, value=escape(str(context.get('Geschlecht', 'N/A'))))}"
+                    f"</span>"
+                )
             else: # Andere Patientenbedingungen
                 specific_description_html += f", Wert/Ref='{escape(werte_aus_regel or feld_ref_patientenbed or '-')}'"
                 # Allgemeine Kontextanzeige für andere Felder
                 kontext_wert_allg = context.get(feld_ref_patientenbed, 'N/A')
-                kontext_erfuellungs_info_html = f" <span class='context-match-info { 'fulfilled' if condition_met_this_line else 'not-fulfilled' }'>(Kontext: {escape(str(kontext_wert_allg))})</span>"
+                kontext_erfuellungs_info_html = (
+                    f" <span class='context-match-info {'fulfilled' if condition_met_this_line else 'not-fulfilled'}'>"
+                    f"{translate('context_value', lang, value=escape(str(kontext_wert_allg)))}"
+                    f"</span>"
+                )
         
         # Die folgenden elif-Blöcke sind NEU für ANZAHL und SEITIGKEIT
         elif bedingungstyp == "ANZAHL":
             vergleichsop_html = cond_definition.get('Vergleichsoperator', '=')
             specific_description_html += f"Anzahl {escape(vergleichsop_html)} {escape(werte_aus_regel)}"
             kontext_wert_anzahl_html = context.get('Anzahl', 'N/A')
-            kontext_erfuellungs_info_html = f" <span class='context-match-info { 'fulfilled' if condition_met_this_line else 'not-fulfilled' }'>(Kontext: {escape(str(kontext_wert_anzahl_html))})</span>"
+            kontext_erfuellungs_info_html = (
+                f" <span class='context-match-info {'fulfilled' if condition_met_this_line else 'not-fulfilled'}'>"
+                f"{translate('context_value', lang, value=escape(str(kontext_wert_anzahl_html)))}"
+                f"</span>"
+            )
 
         elif bedingungstyp == "SEITIGKEIT":
             vergleichsop_html = cond_definition.get('Vergleichsoperator', '=')
             specific_description_html += f"Seitigkeit {escape(vergleichsop_html)} {escape(werte_aus_regel)}" # Zeige Regelwert wie in DB (z.B. 'B')
             kontext_wert_seitigkeit_html = context.get('Seitigkeit', 'N/A') # Kontext ist schon normalisiert (z.B. 'beidseits')
-            kontext_erfuellungs_info_html = f" <span class='context-match-info { 'fulfilled' if condition_met_this_line else 'not-fulfilled' }'>(Kontext: {escape(str(kontext_wert_seitigkeit_html))})</span>"
+            kontext_erfuellungs_info_html = (
+                f" <span class='context-match-info {'fulfilled' if condition_met_this_line else 'not-fulfilled'}'>"
+                f"{translate('context_value', lang, value=escape(str(kontext_wert_seitigkeit_html)))}"
+                f"</span>"
+            )
         
         # Fallback für noch nicht explizit behandelte Typen in der HTML-Generierung
         else:
-            specific_description_html += f"Bedingung: {escape(bedingungstyp)} - Wert: {escape(werte_aus_regel or feld_ref_patientenbed or 'N/A')}"
+            translated_type_fb = translate_condition_type(bedingungstyp, lang)
+            specific_description_html += f"Bedingung: {escape(translated_type_fb)} - Wert: {escape(werte_aus_regel or feld_ref_patientenbed or 'N/A')}"
             # Allgemeine Kontextanzeige
             kontext_wert_fallback = "N/A"
             if feld_ref_patientenbed and feld_ref_patientenbed in context:
                 kontext_wert_fallback = context.get(feld_ref_patientenbed)
             elif bedingungstyp in context: # Falls der Kontext direkt den Typ als Key hat (unwahrscheinlich hier)
                 kontext_wert_fallback = context.get(bedingungstyp)
-            kontext_erfuellungs_info_html = f" <span class='context-match-info { 'fulfilled' if condition_met_this_line else 'not-fulfilled' }'>(Kontext: {escape(str(kontext_wert_fallback))})</span>"
+            kontext_erfuellungs_info_html = (
+                f" <span class='context-match-info {'fulfilled' if condition_met_this_line else 'not-fulfilled'}'>"
+                f"{translate('context_value', lang, value=escape(str(kontext_wert_fallback)))}"
+                f"</span>"
+            )
 
 
         li_content += f"<span class='condition-text-wrapper'>{specific_description_html}{kontext_erfuellungs_info_html}</span>"
@@ -482,13 +565,13 @@ def check_pauschale_conditions(
     )
 
 
-    if not sorted_group_ids: 
-        final_html = "<ul><li>Keine gültigen Bedingungsgruppen gefunden.</li></ul>"
+    if not sorted_group_ids:
+        final_html = f"<ul><li>{translate('no_valid_groups', lang)}</li></ul>"
     elif len(sorted_group_ids) == 1 and sorted_group_ids[0] == 'Ohne_Gruppe':
          # Spezialfall: Nur Bedingungen ohne explizite Gruppe (implizites UND)
          group_id = sorted_group_ids[0]
          group_html_content = "".join(grouped_html_parts[group_id])
-         group_title_text = "Bedingungen (Alle müssen erfüllt sein):"
+         group_title_text = translate('group_conditions', lang)
          final_html = (
             f"<div class='condition-group'>"
             f"<div class='condition-group-title'>{group_title_text}</div>"
@@ -507,9 +590,9 @@ def check_pauschale_conditions(
             
             group_title_text = ""
             if group_id == 'Ohne_Gruppe':
-                group_title_text = "Zusätzliche Bedingungen (Alle müssen erfüllt sein):"
+                group_title_text = translate('group_additional', lang)
             else:
-                group_title_text = f"Logik-Gruppe {escape(str(group_id))} (Alle Bedingungen dieser Gruppe müssen erfüllt sein):"
+                group_title_text = translate('group_logic', lang, id=escape(str(group_id)))
 
             group_wrapper_html = (
                 f"<div class='condition-group'>"
@@ -522,7 +605,9 @@ def check_pauschale_conditions(
             # Füge "ODER" nur zwischen definierten Gruppen hinzu, wenn es mehrere davon gibt
             if group_id != 'Ohne_Gruppe' and is_multigroup_logic and \
                idx < len([gid for gid in sorted_group_ids if gid != 'Ohne_Gruppe']) -1 :
-                final_html_parts.append("<div class='condition-separator'>ODER</div>")
+                final_html_parts.append(
+                    f"<div class='condition-separator'>{translate('or_separator', lang)}</div>"
+                )
         
         final_html = "".join(final_html_parts)
 
@@ -708,7 +793,7 @@ def determine_applicable_pauschale(
     best_pauschale_details = selected_candidate_info["details"].copy() # Kopie für Modifikationen
 
     # Generiere HTML für die Bedingungsprüfung der ausgewählten Pauschale
-    bedingungs_pruef_html_result = "<p><i>Detail-HTML für Bedingungen nicht generiert.</i></p>"
+    bedingungs_pruef_html_result = f"<p><i>{translate('detail_html_not_generated', lang)}</i></p>"
     condition_errors_html_gen = []
     try:
         condition_result_html_dict = check_pauschale_conditions(
@@ -730,25 +815,62 @@ def determine_applicable_pauschale(
     # Erstelle die Erklärung für die Pauschalenauswahl
     # Kontext-LKNs für die Erklärung (aus dem `context` Dictionary)
     lkns_fuer_erklaerung = [str(lkn) for lkn in context.get('LKN', []) if lkn]
-    pauschale_erklaerung_html = (
-        f"<p>Basierend auf dem Kontext (u.a. LKNs: {escape(', '.join(lkns_fuer_erklaerung) or 'keine')}, "
-        f"Seitigkeit: {escape(str(context.get('Seitigkeit')))}, Anzahl: {escape(str(context.get('Anzahl')))}, "
-        f"ICD-Prüfung aktiv: {context.get('useIcd', True)}) wurden folgende Pauschalen geprüft:</p>"
-    )
+    if lang == 'fr':
+        pauschale_erklaerung_html = (
+            f"<p>Sur la base du contexte (p.ex. LKN : {escape(', '.join(lkns_fuer_erklaerung) or 'aucun')}, "
+            f"latéralité : {escape(str(context.get('Seitigkeit')))}, nombre : {escape(str(context.get('Anzahl')))}, "
+            f"vérification ICD active : {context.get('useIcd', True)}) les forfaits suivants ont été vérifiés :</p>"
+        )
+    elif lang == 'it':
+        pauschale_erklaerung_html = (
+            f"<p>Sulla base del contesto (ad es. LKN: {escape(', '.join(lkns_fuer_erklaerung) or 'nessuna')}, "
+            f"lateralità: {escape(str(context.get('Seitigkeit')))}, numero: {escape(str(context.get('Anzahl')))}, "
+            f"verifica ICD attiva: {context.get('useIcd', True)}) sono stati verificati i seguenti forfait:</p>"
+        )
+    else:
+        pauschale_erklaerung_html = (
+            f"<p>Basierend auf dem Kontext (u.a. LKNs: {escape(', '.join(lkns_fuer_erklaerung) or 'keine')}, "
+            f"Seitigkeit: {escape(str(context.get('Seitigkeit')))}, Anzahl: {escape(str(context.get('Anzahl')))}, "
+            f"ICD-Prüfung aktiv: {context.get('useIcd', True)}) wurden folgende Pauschalen geprüft:</p>"
+        )
     
     # Liste aller potenziell geprüften Pauschalen (vor der Validierung)
     pauschale_erklaerung_html += "<ul>"
     for cand_eval in sorted(evaluated_candidates, key=lambda x: x['code']):
-        status_text = '<span style="color:green;">(Bedingungen erfüllt)</span>' if cand_eval['is_valid_structured'] else '<span style="color:red;">(Bedingungen NICHT erfüllt)</span>'
-        pauschale_erklaerung_html += f"<li><b>{escape(cand_eval['code'])}</b>: {escape(get_lang_field(cand_eval['details'], PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')} {status_text}</li>"
+        if cand_eval['is_valid_structured']:
+            status = translate('conditions_met', lang)
+            status_text = f"<span style=\"color:green;\">{status}</span>"
+        else:
+            status = translate('conditions_not_met', lang)
+            status_text = f"<span style=\"color:red;\">{status}</span>"
+        pauschale_erklaerung_html += (
+            f"<li><b>{escape(cand_eval['code'])}</b>: "
+            f"{escape(get_lang_field(cand_eval['details'], PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')} "
+            f"{status_text}</li>"
+        )
     pauschale_erklaerung_html += "</ul>"
     
-    pauschale_erklaerung_html += (
-        f"<p><b>Ausgewählt wurde: {escape(best_pauschale_code)}</b> "
-        f"({escape(get_lang_field(best_pauschale_details, PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')}) - "
-        f"als die Pauschale mit dem niedrigsten Suffix-Buchstaben (z.B. A vor B) unter den gültigen Kandidaten "
-        f"der bevorzugten Kategorie (spezifische Pauschalen vor Fallback-Pauschalen C9x).</p>"
-    )
+    if lang == 'fr':
+        pauschale_erklaerung_html += (
+            f"<p><b>Choix : {escape(best_pauschale_code)}</b> "
+            f"({escape(get_lang_field(best_pauschale_details, PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')}) - "
+            "comme forfait avec la lettre suffixe la plus basse (p. ex. A avant B) parmi les candidats valides "
+            "de la catégorie privilégiée (forfaits spécifiques avant forfaits de secours C9x).</p>"
+        )
+    elif lang == 'it':
+        pauschale_erklaerung_html += (
+            f"<p><b>Selezionato: {escape(best_pauschale_code)}</b> "
+            f"({escape(get_lang_field(best_pauschale_details, PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')}) - "
+            "come forfait con la lettera suffisso più bassa (es. A prima di B) tra i candidati validi "
+            "della categoria preferita (forfait specifici prima dei forfait di fallback C9x).</p>"
+        )
+    else:
+        pauschale_erklaerung_html += (
+            f"<p><b>Ausgewählt wurde: {escape(best_pauschale_code)}</b> "
+            f"({escape(get_lang_field(best_pauschale_details, PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')}) - "
+            f"als die Pauschale mit dem niedrigsten Suffix-Buchstaben (z.B. A vor B) unter den gültigen Kandidaten "
+            f"der bevorzugten Kategorie (spezifische Pauschalen vor Fallback-Pauschalen C9x).</p>"
+        )
 
     # Vergleich mit anderen Pauschalen der gleichen Gruppe (Stamm)
     match_stamm = re.match(r"([A-Z0-9.]+)([A-Z])$", str(best_pauschale_code))
@@ -761,41 +883,67 @@ def determine_applicable_pauschale(
             if str(cand['code']).startswith(pauschalen_stamm_code) and str(cand['code']) != best_pauschale_code
         ]
         if other_evaluated_codes_in_group:
-             pauschale_erklaerung_html += f"<hr><p><b>Vergleich mit anderen Pauschalen der Gruppe '{escape(pauschalen_stamm_code)}':</b></p>"
-             selected_conditions_repr_set = get_simplified_conditions(best_pauschale_code, pauschale_bedingungen_data)
-             
-             for other_cand in sorted(other_evaluated_codes_in_group, key=lambda x: x['code']):
-                  other_code_str = str(other_cand['code'])
-                  other_details_dict = other_cand['details']
-                  other_was_valid_structured = other_cand['is_valid_structured']
-                  validity_info_html = '<span style="color:green;">(Bedingungen auch erfüllt)</span>' if other_was_valid_structured else '<span style="color:red;">(Bedingungen NICHT erfüllt)</span>'
+            if lang == 'fr':
+                pauschale_erklaerung_html += f"<hr><p><b>Comparaison avec d'autres forfaits du groupe '{escape(pauschalen_stamm_code)}':</b></p>"
+            elif lang == 'it':
+                pauschale_erklaerung_html += f"<hr><p><b>Confronto con altri forfait del gruppo '{escape(pauschalen_stamm_code)}':</b></p>"
+            else:
+                pauschale_erklaerung_html += f"<hr><p><b>Vergleich mit anderen Pauschalen der Gruppe '{escape(pauschalen_stamm_code)}':</b></p>"
+            selected_conditions_repr_set = get_simplified_conditions(best_pauschale_code, pauschale_bedingungen_data)
 
-                  other_conditions_repr_set = get_simplified_conditions(other_code_str, pauschale_bedingungen_data)
-                  additional_conditions_for_other = other_conditions_repr_set - selected_conditions_repr_set
-                  missing_conditions_in_other = selected_conditions_repr_set - other_conditions_repr_set
+            for other_cand in sorted(other_evaluated_codes_in_group, key=lambda x: x['code']):
+                other_code_str = str(other_cand['code'])
+                other_details_dict = other_cand['details']
+                other_was_valid_structured = other_cand['is_valid_structured']
+                if other_was_valid_structured:
+                    status = translate('conditions_also_met', lang)
+                    validity_info_html = f"<span style=\"color:green;\">{status}</span>"
+                else:
+                    status = translate('conditions_not_met', lang)
+                    validity_info_html = f"<span style=\"color:red;\">{status}</span>"
 
-                  pauschale_erklaerung_html += (
-                      f"<details style='margin-left: 15px; font-size: 0.9em;'>"
-                      f"<summary>Unterschiede zu <b>{escape(other_code_str)}</b> ({escape(get_lang_field(other_details_dict, PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')}) {validity_info_html}</summary>"
-                  )
+                other_conditions_repr_set = get_simplified_conditions(other_code_str, pauschale_bedingungen_data)
+                additional_conditions_for_other = other_conditions_repr_set - selected_conditions_repr_set
+                missing_conditions_in_other = selected_conditions_repr_set - other_conditions_repr_set
+
+                diff_label = translate('diff_to', lang)
+                pauschale_erklaerung_html += (
+                    f"<details style='margin-left: 15px; font-size: 0.9em;'>"
+                    f"<summary>{diff_label} <b>{escape(other_code_str)}</b> ({escape(get_lang_field(other_details_dict, PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')}) {validity_info_html}</summary>"
+                )
+
+                if additional_conditions_for_other:
+                    if lang == 'fr':
+                        pauschale_erklaerung_html += f"<p>Exigences supplémentaires / autres pour {escape(other_code_str)}:</p><ul>"
+                    elif lang == 'it':
+                        pauschale_erklaerung_html += f"<p>Requisiti supplementari / altri per {escape(other_code_str)}:</p><ul>"
+                    else:
+                        pauschale_erklaerung_html += f"<p>Zusätzliche/Andere Anforderungen für {escape(other_code_str)}:</p><ul>"
+                    for cond_tuple_item in sorted(list(additional_conditions_for_other)):
+                        condition_html_detail_item = generate_condition_detail_html(cond_tuple_item, leistungskatalog_dict, tabellen_dict_by_table, lang)
+                        pauschale_erklaerung_html += condition_html_detail_item
+                    pauschale_erklaerung_html += "</ul>"
                   
-                  if additional_conditions_for_other:
-                      pauschale_erklaerung_html += f"<p>Zusätzliche/Andere Anforderungen für {escape(other_code_str)}:</p><ul>"
-                      for cond_tuple_item in sorted(list(additional_conditions_for_other)):
-                            condition_html_detail_item = generate_condition_detail_html(cond_tuple_item, leistungskatalog_dict, tabellen_dict_by_table, lang)
-                            pauschale_erklaerung_html += condition_html_detail_item
-                      pauschale_erklaerung_html += "</ul>"
-                  
-                  if missing_conditions_in_other:
-                     pauschale_erklaerung_html += f"<p>Folgende Anforderungen von {escape(best_pauschale_code)} fehlen bei {escape(other_code_str)}:</p><ul>"
-                     for cond_tuple_item in sorted(list(missing_conditions_in_other)):
-                         condition_html_detail_item = generate_condition_detail_html(cond_tuple_item, leistungskatalog_dict, tabellen_dict_by_table, lang)
-                         pauschale_erklaerung_html += condition_html_detail_item
-                     pauschale_erklaerung_html += "</ul>"
-                  
-                  if not additional_conditions_for_other and not missing_conditions_in_other:
-                     pauschale_erklaerung_html += "<p><i>Keine unterschiedlichen Kernbedingungen gefunden (basierend auf vereinfachter Typ/Wert-Prüfung). Detaillierte Unterschiede können in der Anzahl oder spezifischen Logikgruppen liegen.</i></p>"
-                  pauschale_erklaerung_html += "</details>"
+                if missing_conditions_in_other:
+                    if lang == 'fr':
+                        pauschale_erklaerung_html += f"<p>Les exigences suivantes de {escape(best_pauschale_code)} manquent pour {escape(other_code_str)}:</p><ul>"
+                    elif lang == 'it':
+                        pauschale_erklaerung_html += f"<p>I seguenti requisiti di {escape(best_pauschale_code)} mancano in {escape(other_code_str)}:</p><ul>"
+                    else:
+                        pauschale_erklaerung_html += f"<p>Folgende Anforderungen von {escape(best_pauschale_code)} fehlen bei {escape(other_code_str)}:</p><ul>"
+                    for cond_tuple_item in sorted(list(missing_conditions_in_other)):
+                        condition_html_detail_item = generate_condition_detail_html(cond_tuple_item, leistungskatalog_dict, tabellen_dict_by_table, lang)
+                        pauschale_erklaerung_html += condition_html_detail_item
+                    pauschale_erklaerung_html += "</ul>"
+
+                if not additional_conditions_for_other and not missing_conditions_in_other:
+                    if lang == 'fr':
+                        pauschale_erklaerung_html += "<p><i>Aucune différence de conditions essentielles trouvée (basé sur un contrôle simplifié type/valeur). Des différences détaillées peuvent exister au niveau du nombre ou de groupes logiques spécifiques.</i></p>"
+                    elif lang == 'it':
+                        pauschale_erklaerung_html += "<p><i>Nessuna differenza nelle condizioni principali trovata (basato su un confronto semplificato tipo/valore). Differenze dettagliate possibili nel numero o in gruppi logici specifici.</i></p>"
+                    else:
+                        pauschale_erklaerung_html += "<p><i>Keine unterschiedlichen Kernbedingungen gefunden (basierend auf vereinfachter Typ/Wert-Prüfung). Detaillierte Unterschiede können in der Anzahl oder spezifischen Logikgruppen liegen.</i></p>"
+                pauschale_erklaerung_html += "</details>"
     
     best_pauschale_details[PAUSCHALE_ERKLAERUNG_KEY] = pauschale_erklaerung_html
 
@@ -808,7 +956,7 @@ def determine_applicable_pauschale(
         if cond_item_icd.get(BED_TYP_KEY, "").upper() == "HAUPTDIAGNOSE IN TABELLE":
             tabelle_ref_icd = cond_item_icd.get(BED_WERTE_KEY)
             if tabelle_ref_icd:
-                icd_entries_list = get_table_content(tabelle_ref_icd, "icd", tabellen_dict_by_table)
+                icd_entries_list = get_table_content(tabelle_ref_icd, "icd", tabellen_dict_by_table, lang)
                 for entry_icd in icd_entries_list:
                     code_icd = entry_icd.get('Code'); text_icd = entry_icd.get('Code_Text')
                     if code_icd: potential_icds_list.append({"Code": code_icd, "Code_Text": text_icd or "N/A"})
@@ -923,9 +1071,9 @@ def generate_condition_detail_html(
     try:
         # Formatierung basierend auf dem normalisierten Typ aus get_simplified_conditions
         if cond_type_comp == 'LKN_LIST':
-            condition_html += f"Erfordert LKN aus Liste: "
+            condition_html += translate('require_lkn_list', lang)
             if not cond_value_comp: # cond_value_comp ist hier ein Tuple von LKNs
-                condition_html += "<i>(Keine LKNs spezifiziert)</i>"
+                condition_html += f"<i>{translate('no_lkns_spec', lang)}</i>"
             else:
                 lkn_details_html_parts = []
                 for lkn_code in cond_value_comp: # Iteriere über das Tuple
@@ -934,83 +1082,85 @@ def generate_condition_detail_html(
                 condition_html += ", ".join(lkn_details_html_parts)
 
         elif cond_type_comp == 'LKN_TABLE':
-            condition_html += f"Erfordert LKN aus Tabelle(n): "
+            condition_html += translate('require_lkn_table', lang)
             if not cond_value_comp: # cond_value_comp ist Tuple von Tabellennamen
-                condition_html += "<i>(Kein Tabellenname spezifiziert)</i>"
+                condition_html += f"<i>{translate('no_table_name', lang)}</i>"
             else:
                 table_links_html_parts = []
                 for table_name_norm in cond_value_comp: # Iteriere über Tuple von normalisierten Tabellennamen
                     # Hole Original-Tabellenname, falls möglich (für Anzeige), sonst normalisierten
                     # Dies ist schwierig ohne die Original-Bedingungsdaten hier.
                     # Wir verwenden den normalisierten Namen für get_table_content.
-                    table_content_entries = get_table_content(table_name_norm, "service_catalog", tabellen_dict_by_table)
+                    table_content_entries = get_table_content(table_name_norm, "service_catalog", tabellen_dict_by_table, lang)
                     entry_count = len(table_content_entries)
                     details_content_html = ""
                     if table_content_entries:
                         details_content_html = "<ul style='margin-top: 5px; font-size: 0.9em; max-height: 150px; overflow-y: auto; border-top: 1px solid #eee; padding-top: 5px; padding-left: 15px; list-style-position: inside;'>"
                         for item in sorted(table_content_entries, key=lambda x: x.get('Code', '')):
-                            item_code = item.get('Code', 'N/A'); item_text = item.get('Code_Text', 'N/A')
+                            item_code = item.get('Code', 'N/A'); item_text = get_beschreibung_fuer_lkn_im_backend(item_code, leistungskatalog_dict, lang)
                             details_content_html += f"<li><b>{html.escape(item_code)}</b>: {html.escape(item_text)}</li>"
                         details_content_html += "</ul>"
+                    entries_label = translate('entries_label', lang)
                     table_detail_html = (
                         f"<details class='inline-table-details-comparison'>"
-                        f"<summary>{html.escape(table_name_norm.upper())}</summary> ({entry_count} Einträge){details_content_html}</details>"
+                        f"<summary>{html.escape(table_name_norm.upper())}</summary> ({entry_count} {entries_label}){details_content_html}</details>"
                     )
                     table_links_html_parts.append(table_detail_html)
                 condition_html += ", ".join(table_links_html_parts)
 
         elif cond_type_comp == 'ICD_TABLE':
-            condition_html += f"Erfordert ICD aus Tabelle(n): "
+            condition_html += translate('require_icd_table', lang)
             if not cond_value_comp: # Tuple von Tabellennamen
-                condition_html += "<i>(Kein Tabellenname spezifiziert)</i>"
+                condition_html += f"<i>{translate('no_table_name', lang)}</i>"
             else:
                 table_links_html_parts = []
                 for table_name_norm in cond_value_comp:
-                    table_content_entries = get_table_content(table_name_norm, "icd", tabellen_dict_by_table)
+                    table_content_entries = get_table_content(table_name_norm, "icd", tabellen_dict_by_table, lang)
                     entry_count = len(table_content_entries)
                     details_content_html = ""
                     if table_content_entries:
-                        details_content_html = "<ul>" # Vereinfacht für Lesbarkeit
+                        details_content_html = "<ul>"
                         for item in sorted(table_content_entries, key=lambda x: x.get('Code', '')):
                             item_code = item.get('Code', 'N/A'); item_text = item.get('Code_Text', 'N/A')
                             details_content_html += f"<li><b>{html.escape(item_code)}</b>: {html.escape(item_text)}</li>"
                         details_content_html += "</ul>"
+                    entries_label = translate('entries_label', lang)
                     table_detail_html = (
                         f"<details class='inline-table-details-comparison'>"
-                        f"<summary>{html.escape(table_name_norm.upper())}</summary> ({entry_count} Einträge){details_content_html}</details>"
+                        f"<summary>{html.escape(table_name_norm.upper())}</summary> ({entry_count} {entries_label}){details_content_html}</details>"
                     )
                     table_links_html_parts.append(table_detail_html)
                 condition_html += ", ".join(table_links_html_parts)
 
         elif cond_type_comp == 'ICD_LIST':
-            condition_html += f"Erfordert ICD aus Liste: "
+            condition_html += translate('require_icd_list', lang)
             if not cond_value_comp: # Tuple von ICDs
-                condition_html += "<i>(Keine ICDs spezifiziert)</i>"
+                condition_html += f"<i>{translate('no_icds_spec', lang)}</i>"
             else:
                 icd_details_html_parts = []
                 for icd_code in cond_value_comp:
-                    beschreibung = get_beschreibung_fuer_icd_im_backend(icd_code, tabellen_dict_by_table)
+                    beschreibung = get_beschreibung_fuer_icd_im_backend(icd_code, tabellen_dict_by_table, lang=lang)
                     icd_details_html_parts.append(f"<b>{html.escape(icd_code)}</b> ({html.escape(beschreibung)})")
                 condition_html += ", ".join(icd_details_html_parts)
         
         elif cond_type_comp == 'GTIN_LIST':
-            condition_html += f"Erfordert GTIN aus Liste: "
-            if not cond_value_comp: condition_html += "<i>(Keine GTINs spezifiziert)</i>"
+            condition_html += translate('require_gtin_list', lang)
+            if not cond_value_comp: condition_html += f"<i>{translate('no_gtins_spec', lang)}</i>"
             else: condition_html += html.escape(", ".join(cond_value_comp))
         
         elif cond_type_comp.startswith('PATIENT_'):
             feld_name = cond_type_comp.split('_', 1)[1].capitalize()
-            condition_html += f"Patientenbedingung ({html.escape(feld_name)}): {html.escape(str(cond_value_comp))}"
+            condition_html += translate('patient_condition', lang, field=html.escape(feld_name), value=html.escape(str(cond_value_comp)))
         
         elif cond_type_comp == 'ANZAHL_CHECK':
-            condition_html += f"Anzahlbedingung: {html.escape(str(cond_value_comp))}"
+            condition_html += translate('anzahl_condition', lang, value=html.escape(str(cond_value_comp)))
 
         elif cond_type_comp == 'SEITIGKEIT_CHECK':
-            condition_html += f"Seitigkeitsbedingung: {html.escape(str(cond_value_comp))}"
+            condition_html += translate('seitigkeit_condition', lang, value=html.escape(str(cond_value_comp)))
         
         elif cond_type_comp == 'GESCHLECHT_LIST_CHECK':
-            condition_html += f"Geschlecht aus Liste: "
-            if not cond_value_comp: condition_html += "<i>(Keine Geschlechter spezifiziert)</i>"
+            condition_html += translate('geschlecht_list', lang)
+            if not cond_value_comp: condition_html += f"<i>{translate('no_gender_spec', lang)}</i>"
             else: condition_html += html.escape(", ".join(cond_value_comp))
 
         else: # Allgemeiner Fallback für andere Typen aus get_simplified_conditions

--- a/utils.py
+++ b/utils.py
@@ -6,8 +6,9 @@ def escape(text: Any) -> str:
     """Escapes HTML special characters in a string."""
     return html.escape(str(text))
 
-def get_table_content(table_ref: str, table_type: str, tabellen_dict_by_table: dict) -> list[dict]:
-    """Holt Einträge für eine Tabelle und einen Typ (Case-Insensitive)."""
+def get_table_content(table_ref: str, table_type: str, tabellen_dict_by_table: dict, lang: str = 'de') -> list[dict]:
+    """Holt Einträge für eine Tabelle und einen Typ (Case-Insensitive).
+    Berücksichtigt die Sprache für den Text."""
     content = []
     # Schlüssel für PAUSCHALEN_Tabellen - anpassen falls nötig!
     TAB_CODE_KEY = 'Code'; TAB_TEXT_KEY = 'Code_Text'; TAB_TYP_KEY = 'Tabelle_Typ'
@@ -24,8 +25,10 @@ def get_table_content(table_ref: str, table_type: str, tabellen_dict_by_table: d
             for entry in tabellen_dict_by_table[normalized_key]: # Greife direkt auf die Liste zu
                 entry_typ = entry.get(TAB_TYP_KEY)
                 if entry_typ and entry_typ.lower() == table_type.lower():
-                    code = entry.get(TAB_CODE_KEY); text = entry.get(TAB_TEXT_KEY)
-                    if code: all_entries_for_type.append({"Code": code, "Code_Text": text or "N/A"})
+                    code = entry.get(TAB_CODE_KEY)
+                    text = get_lang_field(entry, TAB_TEXT_KEY, lang)
+                    if code:
+                        all_entries_for_type.append({"Code": code, "Code_Text": text or "N/A"})
         else:
              print(f"WARNUNG (get_table_content): Normalisierter Schlüssel '{normalized_key}' (Original: '{name}') nicht in tabellen_dict_by_table gefunden.")
 
@@ -38,3 +41,363 @@ def get_lang_field(entry: Dict[str, Any], base_key: str, lang: str) -> Any:
         return None
     suffix = {'de': '', 'fr': '_f', 'it': '_i'}.get(str(lang).lower(), '')
     return entry.get(f"{base_key}{suffix}") or entry.get(base_key)
+
+
+# Einfache Übersetzungsfunktion für Backend-Strings
+_TRANSLATIONS: Dict[str, Dict[str, str]] = {
+    'conditions_met': {
+        'de': '(Bedingungen erfüllt)',
+        'fr': '(Conditions remplies)',
+        'it': '(Condizioni soddisfatte)'
+    },
+    'conditions_not_met': {
+        'de': '(Bedingungen NICHT erfüllt)',
+        'fr': '(Conditions NON remplies)',
+        'it': '(Condizioni NON soddisfatte)'
+    },
+    'conditions_also_met': {
+        'de': '(Bedingungen auch erfüllt)',
+        'fr': '(Conditions aussi remplies)',
+        'it': '(Condizioni pure soddisfatte)'
+    },
+    'group_conditions': {
+        'de': 'Bedingungen (Alle müssen erfüllt sein):',
+        'fr': 'Conditions (toutes doivent être remplies) :',
+        'it': 'Condizioni (tutte devono essere soddisfatte):'
+    },
+    'group_additional': {
+        'de': 'Zusätzliche Bedingungen (Alle müssen erfüllt sein):',
+        'fr': 'Conditions supplémentaires (toutes doivent être remplies) :',
+        'it': 'Condizioni supplementari (tutte devono essere soddisfatte):'
+    },
+    'group_logic': {
+        'de': 'Logik-Gruppe {id} (Alle Bedingungen dieser Gruppe müssen erfüllt sein):',
+        'fr': 'Groupe logique {id} (toutes les conditions de ce groupe doivent être remplies) :',
+        'it': 'Gruppo logico {id} (tutte le condizioni di questo gruppo devono essere soddisfatte):'
+    },
+    'no_valid_groups': {
+        'de': 'Keine gültigen Bedingungsgruppen gefunden.',
+        'fr': 'Aucun groupe de conditions valide trouvé.',
+        'it': 'Nessun gruppo di condizioni valido trovato.'
+    },
+    'detail_html_not_generated': {
+        'de': 'Detail-HTML für Bedingungen nicht generiert.',
+        'fr': "HTML détaillé pour les conditions non généré.",
+        'it': 'HTML dettagliato per le condizioni non generato.'
+    },
+    'require_lkn_list': {
+        'de': 'Erfordert LKN aus Liste: ',
+        'fr': 'NPL requis depuis une liste : ',
+        'it': 'NPL richiesti da una lista: '
+    },
+    'require_lkn_table': {
+        'de': 'Erfordert LKN aus Tabelle(n): ',
+        'fr': 'NPL requis depuis table(s) : ',
+        'it': 'NPL richiesti da tabella/e: '
+    },
+    'no_lkns_spec': {
+        'de': '(Keine LKNs spezifiziert)',
+        'fr': '(Aucun NPL spécifié)',
+        'it': '(Nessun NPL specificato)'
+    },
+    'no_table_name': {
+        'de': '(Kein Tabellenname spezifiziert)',
+        'fr': '(Aucun nom de table spécifié)',
+        'it': '(Nessun nome tabella specificato)'
+    },
+    'require_icd_table': {
+        'de': 'Erfordert ICD aus Tabelle(n): ',
+        'fr': 'ICD requis depuis table(s) : ',
+        'it': 'ICD richiesti da tabella/e: '
+    },
+    'require_icd_list': {
+        'de': 'Erfordert ICD aus Liste: ',
+        'fr': 'ICD requis depuis une liste : ',
+        'it': 'ICD richiesti da una lista: '
+    },
+    'no_icds_spec': {
+        'de': '(Keine ICDs spezifiziert)',
+        'fr': '(Aucun ICD spécifié)',
+        'it': '(Nessun ICD specificato)'
+    },
+    'require_gtin_list': {
+        'de': 'Erfordert GTIN aus Liste: ',
+        'fr': 'GTIN requis depuis une liste : ',
+        'it': 'GTIN richiesti da una lista: '
+    },
+    'no_gtins_spec': {
+        'de': '(Keine GTINs spezifiziert)',
+        'fr': '(Aucune GTIN spécifiée)',
+        'it': '(Nessuna GTIN specificata)'
+    },
+    'patient_condition': {
+        'de': 'Patientenbedingung ({field}): {value}',
+        'fr': 'Condition patient ({field}) : {value}',
+        'it': 'Condizione paziente ({field}) : {value}'
+    },
+    'anzahl_condition': {
+        'de': 'Anzahlbedingung: {value}',
+        'fr': 'Condition sur la quantité : {value}',
+        'it': 'Condizione sul numero: {value}'
+    },
+    'seitigkeit_condition': {
+        'de': 'Seitigkeitsbedingung: {value}',
+        'fr': 'Condition de latéralité : {value}',
+        'it': 'Condizione di lateralità: {value}'
+    },
+    'geschlecht_list': {
+        'de': 'Geschlecht aus Liste: ',
+        'fr': 'Sexe dans la liste : ',
+        'it': 'Sesso in elenco: '
+    },
+    'no_gender_spec': {
+        'de': '(Keine Geschlechter spezifiziert)',
+        'fr': '(Aucun sexe spécifié)',
+        'it': '(Nessun sesso specificato)'
+    },
+    'fulfilled_by': {
+        'de': '(Erfüllt durch: {items})',
+        'fr': '(Rempli par : {items})',
+        'it': '(Soddisfatto da: {items})'
+    },
+    'context_items_not_in_table': {
+        'de': '(Kontext-Element(e) {items} nicht in Regel-Tabelle(n) gefunden)',
+        'fr': '(Élément(s) du contexte {items} non trouvé(s) dans la/les table(s) de règle)',
+        'it': '(Elemento/i di contesto {items} non trovato/i nelle tabelle delle regole)'
+    },
+    'tables_empty': {
+        'de': '(Regel-Tabelle(n) leer oder nicht gefunden)',
+        'fr': '(Table(s) de règle vide(s) ou non trouvée(s))',
+        'it': '(Tabella/e delle regole vuota/e o non trovata/e)'
+    },
+    'context_items_not_in_list': {
+        'de': '(Kontext-Element(e) {items} nicht in Regel-Liste)',
+        'fr': '(Élément(s) du contexte {items} absent(s) de la liste de règle)',
+        'it': '(Elemento/i di contesto {items} non presente/i nell\'elenco della regola)'
+    },
+    'no_context_in_list': {
+        'de': '(Kein Kontext-Element in Regel-Liste)',
+        'fr': '(Aucun élément du contexte dans la liste de règle)',
+        'it': '(Nessun elemento di contesto nell\'elenco della regola)'
+    },
+    'rule_list_empty': {
+        'de': '(Regel-Liste leer)',
+        'fr': '(Liste de règle vide)',
+        'it': '(Elenco della regola vuoto)'
+    },
+    'entries_label': {
+        'de': 'Einträge',
+        'fr': 'entrées',
+        'it': 'voci'
+    },
+    'context_value': {
+        'de': '(Kontext: {value})',
+        'fr': '(Contexte : {value})',
+        'it': '(Contesto: {value})'
+    },
+    'diff_to': {
+        'de': 'Unterschiede zu',
+        'fr': 'Différences avec',
+        'it': 'Differenze rispetto a'
+    },
+    'or_separator': {
+        'de': 'ODER',
+        'fr': 'OU',
+        'it': 'OPPURE'
+    },
+    'rule_qty_exceeded': {
+        'de': 'Mengenbeschränkung überschritten (max. {max}, angefragt {req})',
+        'fr': 'Limite de quantité dépassée (max. {max}, demandé {req})',
+        'it': 'Limite di quantità superata (max. {max}, richiesto {req})'
+    },
+    'rule_qty_reduced': {
+        'de': 'Menge auf {value} reduziert (Mengenbeschränkung)',
+        'fr': 'Quantité réduite à {value} (limitation de quantité)',
+        'it': 'Quantità ridotta a {value} (limitazione di quantità)'
+    },
+    'rule_only_supplement': {
+        'de': 'Nur als Zuschlag zu {code} zulässig (Basis fehlt)',
+        'fr': 'Uniquement comme supplément à {code} (base manquante)',
+        'it': 'Solo come supplemento a {code} (base mancante)'
+    },
+    'rule_not_cumulable': {
+        'de': 'Nicht kumulierbar mit: {codes}',
+        'fr': 'Non cumulable avec : {codes}',
+        'it': 'Non cumulabile con: {codes}'
+    },
+    'rule_patient_field_missing': {
+        'de': 'Patientenbedingung ({field}) nicht erfüllt: Kontextwert fehlt',
+        'fr': 'Condition patient ({field}) non remplie : valeur manquante',
+        'it': 'Condizione paziente ({field}) non soddisfatta: valore mancante'
+    },
+    'rule_patient_age': {
+        'de': 'Patientenbedingung ({detail}) nicht erfüllt (Patient: {value})',
+        'fr': 'Condition patient ({detail}) non remplie (patient : {value})',
+        'it': 'Condizione paziente ({detail}) non soddisfatta (paziente: {value})'
+    },
+    'rule_patient_age_invalid': {
+        'de': 'Patientenbedingung (Alter): Ungültiger Alterswert im Fall ({value})',
+        'fr': "Condition patient (âge) : valeur d'âge non valide ({value})",
+        'it': 'Condizione paziente (età): valore età non valido ({value})'
+    },
+    'rule_patient_gender_mismatch': {
+        'de': 'Patientenbedingung (Geschlecht): erwartet {exp}, gefunden {found}',
+        'fr': 'Condition patient (sexe) : attendu {exp}, trouvé {found}',
+        'it': 'Condizione paziente (sesso): atteso {exp}, trovato {found}'
+    },
+    'rule_patient_gender_invalid': {
+        'de': 'Patientenbedingung (Geschlecht): Ungültige Werte für Geschlechtsprüfung',
+        'fr': 'Condition patient (sexe) : valeurs non valides pour le contrôle du sexe',
+        'it': 'Condizione paziente (sesso): valori non validi per il controllo del sesso'
+    },
+    'rule_patient_gtin_missing': {
+        'de': 'Patientenbedingung (GTIN): Erwartet einen von {required}, nicht gefunden',
+        'fr': "Condition patient (GTIN) : attendu l'un de {required}, non trouvé",
+        'it': 'Condizione paziente (GTIN): previsto uno di {required}, non trovato'
+    },
+    'rule_diagnosis_missing': {
+        'de': 'Erforderliche Diagnose(n) nicht vorhanden (Benötigt: {codes})',
+        'fr': 'Diagnostic(s) requis absent(s) (nécessaire : {codes})',
+        'it': 'Diagnosi richiesta non presente (necessario: {codes})'
+    },
+    'rule_pauschale_exclusion': {
+        'de': 'Leistung nicht zulässig bei gleichzeitiger Abrechnung der Pauschale(n): {codes}',
+        'fr': 'Prestation non admise en cas de facturation simultanée du/des forfait(s) : {codes}',
+        'it': 'Prestazione non ammessa con fatturazione simultanea del/i forfait: {codes}'
+    },
+    'rule_internal_error': {
+        'de': 'Interner Fehler bei Regelprüfung: {error}',
+        'fr': 'Erreur interne lors du contrôle des règles : {error}',
+        'it': 'Errore interno durante il controllo delle regole: {error}'
+    },
+    'rule_check_not_available': {
+        'de': 'Regelprüfung nicht verfügbar.',
+        'fr': 'Contrôle des règles non disponible.',
+        'it': 'Controllo regole non disponibile.'
+    },
+    'rule_check_not_performed': {
+        'de': 'Regelprüfung nicht durchgeführt.',
+        'fr': 'Contrôle des règles non effectué.',
+        'it': 'Controllo regole non eseguito.'
+    },
+    'llm_no_lkn': {
+        'de': 'Keine LKN vom LLM identifiziert/validiert.',
+        'fr': 'Aucun NPL identifié/validé par le LLM.',
+        'it': 'Nessun NPL identificato/validato dal LLM.'
+    }
+
+}
+
+# Zusätzliche Übersetzungen für Bedingungstypen
+_COND_TYPE_TRANSLATIONS: Dict[str, Dict[str, str]] = {
+    'LEISTUNGSPOSITIONEN IN LISTE': {
+        'de': 'LEISTUNGSPOSITIONEN IN LISTE',
+        'fr': 'Positions de prestation dans une liste',
+        'it': 'Posizioni di prestazione in elenco'
+    },
+    'LEISTUNGSPOSITIONEN IN TABELLE': {
+        'de': 'LEISTUNGSPOSITIONEN IN TABELLE',
+        'fr': 'Positions de prestation dans une table',
+        'it': 'Posizioni di prestazione in tabella'
+    },
+    'TARIFPOSITIONEN IN TABELLE': {
+        'de': 'TARIFPOSITIONEN IN TABELLE',
+        'fr': 'Positions tarifaires dans une table',
+        'it': 'Posizioni tariffarie in tabella'
+    },
+    'LKN IN LISTE': {
+        'de': 'LKN IN LISTE',
+        'fr': 'NPL dans une liste',
+        'it': 'NPL in elenco'
+    },
+    'LKN IN TABELLE': {
+        'de': 'LKN IN TABELLE',
+        'fr': 'NPL dans une table',
+        'it': 'NPL in tabella'
+    },
+    'ICD IN LISTE': {
+        'de': 'ICD IN LISTE',
+        'fr': 'ICD dans une liste',
+        'it': 'ICD in elenco'
+    },
+    'ICD IN TABELLE': {
+        'de': 'ICD IN TABELLE',
+        'fr': 'ICD dans une table',
+        'it': 'ICD in tabella'
+    },
+    'HAUPTDIAGNOSE IN TABELLE': {
+        'de': 'HAUPTDIAGNOSE IN TABELLE',
+        'fr': 'Diagnostic principal dans une table',
+        'it': 'Diagnosi principale in tabella'
+    },
+    'MEDIKAMENTE IN LISTE': {
+        'de': 'MEDIKAMENTE IN LISTE',
+        'fr': 'Médicaments dans une liste',
+        'it': 'Farmaci in elenco'
+    },
+    'GESCHLECHT IN LISTE': {
+        'de': 'GESCHLECHT IN LISTE',
+        'fr': 'Sexe dans la liste',
+        'it': 'Sesso in elenco'
+    },
+    'ALTER IN JAHREN BEI EINTRITT': {
+        'de': 'ALTER IN JAHREN BEI EINTRITT',
+        'fr': "Âge en années à l'admission",
+        'it': "Età in anni all'ingresso"
+    },
+    'ANZAHL': {
+        'de': 'ANZAHL',
+        'fr': 'Quantité',
+        'it': 'Quantità'
+    },
+    'SEITIGKEIT': {
+        'de': 'SEITIGKEIT',
+        'fr': 'Latéralité',
+        'it': 'Lateralità'
+    }
+}
+
+def translate(key: str, lang: str = 'de', **kwargs) -> str:
+    """Einfache Übersetzung bestimmter Texte mit Platzhaltern."""
+    lang = str(lang).lower()
+    template = _TRANSLATIONS.get(key, {}).get(lang) or _TRANSLATIONS.get(key, {}).get('de') or key
+    return template.format(**kwargs)
+
+def translate_rule_error_message(msg: str, lang: str = 'de') -> str:
+    """Übersetzt häufige Regelprüfer-Meldungen anhand einfacher Muster."""
+    if lang == 'de' or not msg:
+        return msg
+    import re
+    patterns = [
+        (r'^Mengenbeschränkung überschritten \(max\. (?P<max>\d+), angefragt (?P<req>\d+)\)$', 'rule_qty_exceeded'),
+        (r'^Menge auf (?P<value>\d+) reduziert \(Mengenbeschränkung\)$', 'rule_qty_reduced'),
+        (r'^Nur als Zuschlag zu (?P<code>[A-Z0-9.]+) zulässig \(Basis fehlt\)$', 'rule_only_supplement'),
+        (r'^Nicht kumulierbar mit: (?P<codes>.+)$', 'rule_not_cumulable'),
+        (r'^Patientenbedingung \((?P<field>[^)]+)\) nicht erfüllt: Kontextwert fehlt$', 'rule_patient_field_missing'),
+        (r'^Patientenbedingung \((?P<detail>[^)]+)\) nicht erfüllt \(Patient: (?P<value>[^)]+)\)$', 'rule_patient_age'),
+        (r'^Patientenbedingung \(Alter\): Ungültiger Alterswert im Fall \((?P<value>[^)]+)\)$', 'rule_patient_age_invalid'),
+        (r"^Patientenbedingung \(Geschlecht\): erwartet '(?P<exp>[^']+)', gefunden '(?P<found>[^']+)'$", 'rule_patient_gender_mismatch'),
+        (r'^Patientenbedingung \(Geschlecht\): Ungültige Werte für Geschlechtsprüfung$', 'rule_patient_gender_invalid'),
+        (r"^Patientenbedingung \(GTIN\): Erwartet einen von (?P<required>.+), nicht gefunden$", 'rule_patient_gtin_missing'),
+        (r'^Erforderliche Diagnose\(n\) nicht vorhanden \(Benötigt: (?P<codes>.+)\)$', 'rule_diagnosis_missing'),
+        (r'^Leistung nicht zulässig bei gleichzeitiger Abrechnung der Pauschale\(n\): (?P<codes>.+)$', 'rule_pauschale_exclusion'),
+        (r'^Interner Fehler bei Regelprüfung: (?P<error>.+)$', 'rule_internal_error'),
+        (r'^Regelprüfung nicht verfügbar\.$', 'rule_check_not_available'),
+        (r'^Regelprüfung nicht durchgeführt\.$', 'rule_check_not_performed'),
+        (r'^Keine LKN vom LLM identifiziert/validiert\.$', 'llm_no_lkn'),
+    ]
+    for pattern, key in patterns:
+        m = re.match(pattern, msg)
+        if m:
+            return translate(key, lang, **m.groupdict())
+    return msg
+
+def translate_condition_type(cond_type: str, lang: str = 'de') -> str:
+    """Übersetzt bekannte Pauschalen-Bedingungstypen."""
+    if not cond_type:
+        return cond_type
+    translations = _COND_TYPE_TRANSLATIONS.get(cond_type)
+    if not translations:
+        return cond_type
+    lang = str(lang).lower()
+    return translations.get(lang, translations.get('de', cond_type))


### PR DESCRIPTION
## Summary
- include language support when fetching table data
- translate ICD descriptions in pauschalen explanations

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68541a39640c8323971111af8f46c896