### PR TITLE
Fix ICD check for pauschale selection

### DIFF
--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -36,13 +36,13 @@ def check_single_condition(
 
     try:
         if bedingungstyp == "ICD": # ICD IN LISTE
-            if not check_icd_conditions_at_all: return True
+            if not check_icd_conditions_at_all: return False
             required_icds_in_rule_list = {w.strip().upper() for w in str(werte_str).split(',') if w.strip()}
             if not required_icds_in_rule_list: return True # Leere Regel-Liste ist immer erfüllt
             return any(req_icd in provided_icds_upper for req_icd in required_icds_in_rule_list)
 
         elif bedingungstyp == "HAUPTDIAGNOSE IN TABELLE": # ICD IN TABELLE
-            if not check_icd_conditions_at_all: return True
+            if not check_icd_conditions_at_all: return False
             table_ref = werte_str
             icd_codes_in_rule_table = {entry['Code'].upper() for entry in get_table_content(table_ref, "icd", tabellen_dict_by_table) if entry.get('Code')}
             if not icd_codes_in_rule_table: # Wenn Tabelle leer oder nicht gefunden

--- a/tests/test_pauschale_logic.py
+++ b/tests/test_pauschale_logic.py
@@ -1,4 +1,7 @@
 import unittest
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from regelpruefer_pauschale import evaluate_structured_conditions
 
 class TestPauschaleLogic(unittest.TestCase):


### PR DESCRIPTION
## Summary
- return False for ICD conditions when ICD checking is disabled
- make tests import project root for module discovery

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6855632d18b4832385c4af78e40c8467