### PR TITLE
Add keyword extraction helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Der Assistent ist in den drei Landessprachen DE, FR und IT verfügbar. Die Sprac
 
 2.  **Backend (Python/Flask - `server.py`):**
     *   Empfängt Anfragen vom Frontend.
-    *   **LLM Stufe 1 (`call_gemini_stage1`):** Identifiziert LKNs und extrahiert Kontext aus dem Benutzertest mithilfe von Google Gemini. Der übergebene Ausschnitt aus `LKAAT_Leistungskatalog.json` wird nun anhand der Benutzereingabe gefiltert (max. 200 Treffer).
+    *   **LLM Stufe 1 (`call_gemini_stage1`):** Identifiziert LKNs und extrahiert Kontext aus dem Benutzertest mithilfe von Google Gemini. Der übergebene Ausschnitt aus `LKAAT_Leistungskatalog.json` wird nun anhand der Benutzereingabe gefiltert (max. 200 Treffer). Sehr häufige Wörter werden dabei ignoriert.
     *   **Regelprüfung LKN (`regelpruefer.py`):** Prüft die identifizierten LKNs auf Konformität mit TARDOC-Regeln (Menge, Kumulation etc.) basierend auf den im TARDOC-Datensatz eingebetteten Regeldefinitionen.
     *   **Pauschalenpotenzial-Prüfung:** Stellt frühzeitig fest, ob aufgrund der von LLM Stufe 1 gefundenen LKN-Typen überhaupt eine Pauschale in Frage kommt.
     *   **Kontextanreicherung (LKN-Mapping - `call_gemini_stage2_mapping`):**

--- a/server.py
+++ b/server.py
@@ -14,6 +14,7 @@ from utils import (
     get_table_content,
     translate_rule_error_message,
     expand_compound_words,
+    extract_keywords,
 )
 import html
 from prompts import get_stage1_prompt, get_stage2_mapping_prompt, get_stage2_ranking_prompt
@@ -850,7 +851,7 @@ def analyze_billing():
     try:
         katalog_context_parts = []
         preprocessed_input = expand_compound_words(user_input)
-        tokens = set(re.findall(r"\b\w+\b", preprocessed_input.lower()))
+        tokens = extract_keywords(user_input)
         for lkn_code, details in leistungskatalog_dict.items():
             raw_desc = str(details.get("Beschreibung", "N/A"))
             expanded_desc = expand_compound_words(raw_desc)

--- a/utils.py
+++ b/utils.py
@@ -1,6 +1,6 @@
 # utils.py
 import html
-from typing import Dict, List, Any
+from typing import Dict, List, Any, Set
 import re
 
 def escape(text: Any) -> str:
@@ -436,4 +436,37 @@ def expand_compound_words(text: str) -> str:
     if additions:
         return text + " " + " ".join(additions)
     return text
+
+
+# Sehr allgemeine deutsche Wörter, die bei der Keyword-Extraktion ignoriert
+# werden sollen. Nur Kleinschreibung verwenden, da ``extract_keywords`` die
+# Tokens bereits konvertiert.
+STOPWORDS: Set[str] = {
+    "und",
+    "oder",
+    "die",
+    "der",
+    "das",
+    "des",
+    "durch",
+    "mit",
+    "von",
+    "im",
+    "in",
+    "für",
+    "per",
+}
+
+
+def extract_keywords(text: str) -> Set[str]:
+    """Return significant keywords from ``text``.
+
+    Das Eingabewort wird zunächst mit :func:`expand_compound_words` erweitert.
+    Anschließend werden alle Tokens in Kleinschreibung extrahiert und solche mit
+    weniger als vier Buchstaben oder in :data:`STOPWORDS` verworfen.
+    """
+
+    expanded = expand_compound_words(text)
+    tokens = re.findall(r"\b\w+\b", expanded.lower())
+    return {t for t in tokens if len(t) >= 4 and t not in STOPWORDS}
 


### PR DESCRIPTION
## Summary
- implement `extract_keywords` helper in utils
- use helper when filtering Leistungskatalog entries
- mention ignoring common words in README

## Testing
- `python -m unittest discover -s tests`

------
https://chatgpt.com/codex/tasks/task_e_685a6f9d79f48323b3a8453b42ad3e56