### PR TITLE
Allow disabling ICD checks

### DIFF
--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -36,13 +36,13 @@ def check_single_condition(
 
     try:
         if bedingungstyp == "ICD": # ICD IN LISTE
-            if not check_icd_conditions_at_all: return False
+            if not check_icd_conditions_at_all: return True
             required_icds_in_rule_list = {w.strip().upper() for w in str(werte_str).split(',') if w.strip()}
             if not required_icds_in_rule_list: return True # Leere Regel-Liste ist immer erfüllt
             return any(req_icd in provided_icds_upper for req_icd in required_icds_in_rule_list)
 
         elif bedingungstyp == "HAUPTDIAGNOSE IN TABELLE": # ICD IN TABELLE
-            if not check_icd_conditions_at_all: return False
+            if not check_icd_conditions_at_all: return True
             table_ref = werte_str
             icd_codes_in_rule_table = {entry['Code'].upper() for entry in get_table_content(table_ref, "icd", tabellen_dict_by_table) if entry.get('Code')}
             if not icd_codes_in_rule_table: # Wenn Tabelle leer oder nicht gefunden

--- a/tests/test_pauschale_logic.py
+++ b/tests/test_pauschale_logic.py
@@ -135,5 +135,21 @@ class TestPauschaleLogic(unittest.TestCase):
             evaluate_structured_conditions("TEST2", context, conditions, {})
         )
 
+    def test_icd_condition_ignored_when_use_icd_false(self):
+        conditions = [
+            {
+                "BedingungsID": 1,
+                "Pauschale": "ICDTEST",
+                "Gruppe": 1,
+                "Operator": "UND",
+                "Bedingungstyp": "ICD",
+                "Werte": "A12"
+            }
+        ]
+        context = {"ICD": [], "useIcd": False}
+        self.assertTrue(
+            evaluate_structured_conditions("ICDTEST", context, conditions, {})
+        )
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- change ICD-related condition checks so ICD rules are considered met when `useIcd` is `False`
- test that ICD rules are skipped if ICD checking is disabled

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a73a8606c8323bef2e2dddb16f10c