### PR TITLE
Fix operator evaluation order for Pauschale logic

### DIFF
--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -214,17 +214,19 @@ def evaluate_structured_conditions(
         if not conditions_in_group:
             continue  # Leere Gruppe überspringen
 
-        # Link conditions strictly von links nach rechts. Der Operator einer
-        # Bedingungszeile verbindet diese mit der *nächsten* Zeile.
+        # Link conditions strictly from left to right. In the original Excel
+        # export of the rules, the operator stored in a row describes how that
+        # row combines with the *previous* row. Therefore the first row of a
+        # group usually has an operator that is ignored.
         result_ltr = check_single_condition(
             conditions_in_group[0], context, tabellen_dict_by_table
         )
         for idx in range(1, len(conditions_in_group)):
-            prev_op = conditions_in_group[idx - 1].get(OPERATOR_KEY, "UND").upper()
+            cur_op = conditions_in_group[idx].get(OPERATOR_KEY, "UND").upper()
             cur_res = check_single_condition(
                 conditions_in_group[idx], context, tabellen_dict_by_table
             )
-            if prev_op == "UND":
+            if cur_op == "UND":
                 result_ltr = result_ltr and cur_res
             else:  # ODER
                 result_ltr = result_ltr or cur_res


### PR DESCRIPTION
## Summary
- revert change to `PAUSCHALEN_Bedingungen.json`
- interpret `Operator` as link to the previous row
- update tests for the corrected semantics

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685a93d317248323a6dc836dbce04862