### PR TITLE
Add quality endpoint test

### DIFF
--- a/server.py
+++ b/server.py
@@ -1188,6 +1188,18 @@ def analyze_billing():
     logger.info(f"Final response payload for /api/analyze-billing: {json.dumps(final_response_payload, ensure_ascii=False, indent=2)}")
     return jsonify(final_response_payload)
 
+@app.route('/api/quality', methods=['POST'])
+def quality_endpoint():
+    """Simple quality check endpoint returning baseline comparison."""
+    if not request.is_json:
+        return jsonify({"error": "Request must be JSON"}), 400
+    data = request.get_json() or {}
+    baseline = data.get("baseline")
+    # For now, echo baseline as result
+    result = baseline
+    match = result == baseline
+    return jsonify({"result": result, "baseline": baseline, "match": match})
+
 # --- Static‑Routes & Start ---
 @app.route("/")
 def index_route(): # Umbenannt, um Konflikt mit Modul 'index' zu vermeiden, falls es existiert

--- a/tests/test_quality_endpoint.py
+++ b/tests/test_quality_endpoint.py
@@ -1,0 +1,17 @@
+import unittest
+from unittest.mock import patch
+import server
+
+class TestQualityEndpoint(unittest.TestCase):
+    @patch('server.load_data', return_value=True)
+    def test_quality_endpoint(self, _):
+        app = server.create_app()
+        app.config['TESTING'] = True
+        with app.test_client() as client:
+            baseline = {"code": "TEST"}
+            response = client.post('/api/quality', json={'baseline': baseline})
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()
+            self.assertIn('result', data)
+            self.assertIn('baseline', data)
+            self.assertIn('match', data)

--- a/tests/test_quality_endpoint.py
+++ b/tests/test_quality_endpoint.py
@@ -5,9 +5,8 @@ import server
 class TestQualityEndpoint(unittest.TestCase):
     @patch('server.load_data', return_value=True)
     def test_quality_endpoint(self, _):
-        app = server.create_app()
-        app.config['TESTING'] = True
-        with app.test_client() as client:
+        server.app.config['TESTING'] = True
+        with server.app.test_client() as client:
             baseline = {"code": "TEST"}
             response = client.post('/api/quality', json={'baseline': baseline})
             self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
## Summary
- implement a small `/api/quality` endpoint that echoes baseline data
- add tests for the quality endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_685a978c9a888323ac7e4f2aa5db37b5