### PR TITLE
Fix Pylance attribute warnings

### DIFF
--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -5,6 +5,14 @@ from typing import Dict, List, Any, Set # <-- Set hier importieren
 from utils import escape, get_table_content, get_lang_field, translate, translate_condition_type
 import re, html
 
+__all__ = [
+    "evaluate_structured_conditions",
+    "check_pauschale_conditions",
+    "get_simplified_conditions",
+    "generate_condition_detail_html",
+    "determine_applicable_pauschale",
+]
+
 # === FUNKTION ZUR PRÜFUNG EINER EINZELNEN BEDINGUNG ===
 def check_single_condition(
     condition: Dict,

--- a/server.py
+++ b/server.py
@@ -154,19 +154,19 @@ try:
     else: print("FEHLER: 'evaluate_structured_conditions' nicht in regelpruefer_pauschale.py (oder Modul nicht geladen)! Fallback aktiv.")
 
     if rpp_module and hasattr(rpp_module, 'check_pauschale_conditions'):
-        check_pauschale_conditions = rpp_module.check_pauschale_conditions
+        check_pauschale_conditions = rpp_module.check_pauschale_conditions  # type: ignore[attr-defined]
     else: print("FEHLER: 'check_pauschale_conditions' nicht in regelpruefer_pauschale.py (oder Modul nicht geladen)! Fallback aktiv.")
 
     if rpp_module and hasattr(rpp_module, 'get_simplified_conditions'):
-        get_simplified_conditions = rpp_module.get_simplified_conditions
+        get_simplified_conditions = rpp_module.get_simplified_conditions  # type: ignore[attr-defined]
     else: print("FEHLER: 'get_simplified_conditions' nicht in regelpruefer_pauschale.py (oder Modul nicht geladen)! Fallback aktiv.")
 
     if rpp_module and hasattr(rpp_module, 'generate_condition_detail_html'):
-        generate_condition_detail_html = rpp_module.generate_condition_detail_html
+        generate_condition_detail_html = rpp_module.generate_condition_detail_html  # type: ignore[attr-defined]
     else: print("FEHLER: 'generate_condition_detail_html' nicht in regelpruefer_pauschale.py (oder Modul nicht geladen)! Fallback aktiv.")
 
     if rpp_module and hasattr(rpp_module, 'determine_applicable_pauschale'):
-        determine_applicable_pauschale_func = rpp_module.determine_applicable_pauschale
+        determine_applicable_pauschale_func = rpp_module.determine_applicable_pauschale  # type: ignore[attr-defined]
         print("DEBUG: 'determine_applicable_pauschale' aus regelpruefer_pauschale.py zugewiesen.")
     else: print("FEHLER: 'determine_applicable_pauschale' nicht in regelpruefer_pauschale.py (oder Modul nicht geladen)! Fallback aktiv.")
 


### PR DESCRIPTION
## Summary
- export functions from `regelpruefer_pauschale`
- silence Pylance's dynamic attribute warnings

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6862463e26308323b8a915525ddfa609