### PR TITLE
Add evaluated pauschalen to API output

### DIFF
--- a/server.py
+++ b/server.py
@@ -1254,7 +1254,8 @@ def analyze_billing():
         "llm_ergebnis_stufe1": llm_stage1_result,
         "regel_ergebnisse_details": regel_ergebnisse_details_list,
         "abrechnung": finale_abrechnung_obj,
-        "llm_ergebnis_stufe2": llm_stage2_mapping_results
+        "llm_ergebnis_stufe2": llm_stage2_mapping_results,
+        "evaluated_pauschalen": finale_abrechnung_obj.get("evaluated_pauschalen", [])
     }
     if fallback_pauschale_search:
         final_response_payload["fallback_pauschale_search"] = True

--- a/tests/test_analyze_billing_endpoint.py
+++ b/tests/test_analyze_billing_endpoint.py
@@ -1,0 +1,39 @@
+import unittest
+from unittest.mock import patch
+import server
+
+class TestAnalyzeBillingEndpoint(unittest.TestCase):
+    @patch('server.determine_applicable_pauschale_func')
+    @patch('server.load_data', return_value=True)
+    def test_analyze_billing_returns_evaluated(self, _, mock_determine):
+        mock_determine.return_value = {
+            "type": "Pauschale",
+            "details": {"Pauschale": "X"},
+            "bedingungs_pruef_html": "<p></p>",
+            "bedingungs_fehler": [],
+            "conditions_met": True,
+            "evaluated_pauschalen": [
+                {
+                    "code": "X",
+                    "details": {"Taxpunkte": "1"},
+                    "is_valid_structured": True,
+                    "bedingungs_pruef_html": "<p></p>",
+                    "taxpunkte": 1.0,
+                }
+            ],
+        }
+        server.app.config['TESTING'] = True
+        with server.app.test_client() as client:
+            payload = {"inputText": "test", "icd": [], "gtin": []}
+            response = client.post('/api/analyze-billing', json=payload)
+            self.assertEqual(response.status_code, 200)
+            data = response.get_json()
+            self.assertIn('evaluated_pauschalen', data)
+            self.assertIsInstance(data['evaluated_pauschalen'], list)
+            first = data['evaluated_pauschalen'][0]
+            self.assertIn('code', first)
+            self.assertIn('bedingungs_pruef_html', first)
+            self.assertIn('taxpunkte', first)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- return list of evaluated candidates from `determine_applicable_pauschale`
- forward this list via `/api/analyze-billing`
- test that evaluated pauschalen appear in the API response

## Testing
- `python -m unittest discover -v tests` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68628d71dca883239192eafe1cc1ea0d