### PR TITLE
Add additional pauschalen view

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,6 +269,10 @@
         #output .error { color: var(--danger); font-weight: bold; }
         #output .success { color: var(--accent); font-weight: bold; }
 
+        #additionalPauschalen, #pauschaleComparison {
+            margin-top: 15px;
+        }
+
         #spinner {
             display: none; margin-top: 15px; padding: 10px;
             background-color: #eee; border: 1px solid #ccc;
@@ -372,6 +376,8 @@
     <button id="analyzeButton" onclick="getBillingAnalysis()">Tarifpositionen finden</button>
     <div id="spinner">Wird geladen...</div>
     <div id="output">Hier erscheinen die Ergebnisse...</div>
+    <div id="additionalPauschalen"></div>
+    <div id="pauschaleComparison"></div>
 
     <div class="disclaimer" id="disclaimer">
         <strong>Haftungsausschluss:</strong> Alle Auskünfte erfolgen ohne Gewähr... (<a href="https://tarifbrowser.oaat-otma.ch/startPortal" target="_blank">OAAT-OTMA Online-Portal</a>).


### PR DESCRIPTION
## Summary
- show containers for extra pauschalen and comparisons
- allow comparing evaluated pauschalen in calculator.js
- store and render alternative pauschalen list
- add translations for new texts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68628d77fa588323aef98974998caf8c