### PR TITLE
Add modal pauschale info links

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -537,6 +537,27 @@ function showPauschaleComparison(idx) {
     if (back) back.addEventListener('click', (ev) => { ev.preventDefault(); container.innerHTML = ''; });
 }
 
+function buildPauschaleInfoHtml(idx) {
+    if (!evaluatedPauschalenList[idx]) return '';
+    const p = evaluatedPauschalenList[idx];
+    const parse = v => parseFloat(String(v).replace(',', '.')) || 0;
+    const selTp = parse(selectedPauschaleDetails?.Taxpunkte);
+    const otherTp = parse(p.details?.Taxpunkte);
+    const diff = otherTp - selTp;
+    const diffTxt = `${diff >= 0 ? '+' : ''}${diff.toFixed(2)}`;
+    let html = `<h4>${escapeHtml(p.details?.Pauschale || '')} <small>${tDyn('diffTaxpoints')}: ${diffTxt}</small></h4>`;
+    html += displayPauschale(p);
+    return html;
+}
+
+function showPauschaleInfoByCode(code) {
+    const norm = String(code || '').toUpperCase();
+    const idx = evaluatedPauschalenList.findIndex(p => String(p.details?.Pauschale || '').toUpperCase() === norm);
+    if (idx === -1) return;
+    const html = buildPauschaleInfoHtml(idx);
+    showInfoModal(html);
+}
+
 
 function displayOutput(html, type = "info") {
     const out = $("output");
@@ -727,6 +748,13 @@ document.addEventListener("DOMContentLoaded", () => {
             else if (type === 'chapter') html = buildChapterInfoHtml(code);
             else if (type === 'group') html = buildGroupInfoHtml(code);
             showInfoModal(html);
+        }
+
+        const pLink = e.target.closest('a.pauschale-exp-link');
+        if (pLink) {
+            e.preventDefault();
+            const code = (pLink.dataset.code || '').trim();
+            showPauschaleInfoByCode(code);
         }
     });
 });

--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -904,8 +904,10 @@ def determine_applicable_pauschale(
         else:
             status = translate('conditions_not_met', lang)
             status_text = f"<span style=\"color:red;\">{status}</span>"
+        code_str = escape(cand_eval['code'])
+        link = f"<a href='#' class='pauschale-exp-link' data-code='{code_str}'>{code_str}</a>"
         pauschale_erklaerung_html += (
-            f"<li><b>{escape(cand_eval['code'])}</b>: "
+            f"<li><b>{link}</b>: "
             f"{escape(get_lang_field(cand_eval['details'], PAUSCHALE_TEXT_KEY_IN_PAUSCHALEN, lang) or 'N/A')} "
             f"{status_text}</li>"
         )


### PR DESCRIPTION
## Summary
- link candidate codes in `Begründung Pauschalenauswahl` directly to modal
- add JS handlers for these links to show pauschale info

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for flask)*

------
https://chatgpt.com/codex/tasks/task_e_6863a03f7c2883238cabf8f7f68e9c90