### PR TITLE
Add operator-aware condition evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,11 @@ Der Assistent ist in den drei Landessprachen DE, FR und IT verfügbar. Die Sprac
         *   Versucht, TARDOC E/EZ-LKNs auf funktional äquivalente LKNs (oft Typ P/PZ) zu mappen, die als Bedingungen in den potenziellen Pauschalen vorkommen. Die Kandidatenliste für das Mapping wird dynamisch aus den Bedingungen der potenziell relevanten Pauschalen generiert.
     *   **Pauschalen-Anwendbarkeitsprüfung (`regelpruefer_pauschale.py`):**
         *   **Potenzielle Pauschalen finden:** Identifiziert mögliche Pauschalen basierend auf den regelkonformen LKNs (aus `rule_checked_leistungen`) unter Verwendung von `PAUSCHALEN_Leistungspositionen.json` und den LKN-Bedingungen in `PAUSCHALEN_Bedingungen.json`.
-        *   **Strukturierte Bedingungsprüfung (`evaluate_structured_conditions`):** Prüft für jede potenzielle Pauschale, ob ihre Bedingungsgruppen erfüllt sind. Zwischen den Gruppen gilt ein konfigurierbarer `GruppenOperator` (Standard `UND`), innerhalb einer Gruppe wird der `Operator` jeder Zeile mit `UND`-Vorrang ausgewertet. Berücksichtigt das `useIcd`-Flag.
+        *   **Strukturierte Bedingungsprüfung (`evaluate_structured_conditions`):** Prüft für jede potenzielle Pauschale, ob ihre Bedingungsgruppen erfüllt sind. Zwischen den Gruppen gilt ein konfigurierbarer `GruppenOperator` (Standard `UND`). Innerhalb einer Gruppe wird die Spalte `Operator` (`UND`/`ODER`) jeder Zeile beachtet und mit "UND vor ODER" ausgewertet. So lässt sich aus einer Zeilenfolge wie
+          1. `SEITIGKEIT = B` (Operator `ODER`)
+          2. `ANZAHL >= 2`  (Operator `UND`)
+          3. `LKN IN LISTE OP`
+          der Ausdruck `(SEITIGKEIT = B ODER ANZAHL >= 2) UND LKN IN LISTE OP` ableiten. Berücksichtigt wird zudem das `useIcd`-Flag.
         *   **Auswahl der besten Pauschale (`determine_applicable_pauschale`):** Wählt aus den struktur-gültigen Pauschalen die "komplexeste passende" (niedrigster Suffix-Buchstabe, z.B. A vor B vor E) aus der bevorzugten Kategorie (spezifisch vor Fallback).
         *   Generiert detailliertes HTML für die Bedingungsprüfung und eine Begründung der Auswahl.
     *   **Entscheidung & TARDOC-Vorbereitung:** Entscheidet "Pauschale vor TARDOC". Wenn keine Pauschale anwendbar ist, bereitet es die TARDOC-Liste (`regelpruefer.prepare_tardoc_abrechnung`) vor.

--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -254,14 +254,19 @@ def evaluate_structured_conditions(
             conditions_in_group, key=lambda c: c.get("BedingungsID", 0)
         )
 
-        group_result = True
-        for cond in conditions_sorted:
-            cur_res = check_single_condition(cond, context, tabellen_dict_by_table)
-            if not cur_res:
-                group_result = False
-                break
+        # Erste Bedingung auswerten
+        first_res = check_single_condition(conditions_sorted[0], context, tabellen_dict_by_table)
+        result = first_res
+        # Nachfolgende Bedingungen sequentiell mit Operator der vorigen Zeile verknüpfen
+        for idx in range(1, len(conditions_sorted)):
+            prev_op = str(conditions_sorted[idx-1].get(OPERATOR_KEY, "UND")).upper()
+            cur_res = check_single_condition(conditions_sorted[idx], context, tabellen_dict_by_table)
+            if prev_op == "UND":
+                result = result and cur_res
+            else:
+                result = result or cur_res
 
-        group_results.append(group_result)
+        group_results.append(bool(result))
     if not group_results:
         return False
 


### PR DESCRIPTION
## Summary
- respect the `Operator` column when evaluating structured conditions
- evaluate conditions sequentially, combining rows according to the previous operator
- clarify operator precedence in README
- adjust existing unit tests and add mixed operator case for `C04.51B`

## Testing
- `pytest tests/test_pauschale_logic.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6863a06013c8832380f1933ea71ed932