### PR TITLE
Add pytest usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ der Klartext der jeweiligen Frage gespeichert, sodass die passenden Baselines
 einfach gefunden werden können. Über `quality.html` lassen sich diese Beispiele
 gegen die Baselines testen.
 
+## Unittests mit `pytest`
+
+Die Python-Tests liegen im Verzeichnis `tests/` und werden mit `pytest`
+ausgeführt. Vor dem Start der Tests müssen sämtliche Abhängigkeiten installiert
+sein:
+
+```bash
+pip install -r requirements.txt
+pytest
+```
+
+Die Tests setzen unter anderem Flask und weitere Pakete aus der
+`requirements.txt` voraus.
+
 ## Disclaimer
 
 Alle Auskünfte erfolgen ohne Gewähr. Diese Anwendung ist ein Prototyp und dient nur zu Demonstrations- und Testzwecken. Für offizielle und verbindliche Informationen konsultieren Sie bitte das Portal  OAAT-OTMA AG: [https://tarifbrowser.oaat-otma.ch/startPortal](https://tarifbrowser.oaat-otma.ch/startPortal).


### PR DESCRIPTION
## Summary
- document running tests with `pytest`

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement Flask)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6863e095b6e883238a50713c4f18d422