### PR TITLE
Add export_pauschalen_table helper and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,21 @@ Der Assistent ist in den drei Landessprachen DE, FR und IT verfügbar. Die Sprac
     ```
     Es entsteht eine `*.clean.json`-Datei, die zum Testen verwendet werden kann.
 
-7.  **API-Schlüssel konfigurieren:**
+7.  **(Optional) Pauschalen-Tabellen exportieren:**
+    Nutze `export_pauschalen_table.py`, um binäre Werte in den Feldern
+    `Ebene` und `Gruppe` zu bereinigen.
+    ```bash
+    python export_pauschalen_table.py data/PAUSCHALEN_Bedingungen.json \
+        data/PAUSCHALEN_Bedingungen.clean.json
+    ```
+8.  **API-Schlüssel konfigurieren:**
     *   Erstelle eine Datei namens `.env` im Hauptverzeichnis.
     *   Füge deinen Google Gemini API-Schlüssel hinzu:
         ```env
         GEMINI_API_KEY="DEIN_API_SCHLUESSEL_HIER"
         # Optional: GEMINI_MODEL="gemini-1.5-pro-latest"
         ```
-8.  **Anwendung starten:**
+9.  **Anwendung starten:**
     ```bash
     python server.py
     ```

--- a/export_pauschalen_table.py
+++ b/export_pauschalen_table.py
@@ -1,0 +1,44 @@
+import json
+from pathlib import Path
+from typing import Any, List, Dict
+
+
+def _decode_numeric_field(value: Any) -> Any:
+    """Convert byte-like strings ("\x01\x00\x00\x00") to integers."""
+    if isinstance(value, str) and len(value) == 4 and all(ord(c) < 32 for c in value):
+        try:
+            return int.from_bytes(value.encode('latin-1'), 'little')
+        except Exception:
+            return value
+    return value
+
+
+def export_pauschalen_table(in_path: Path, out_path: Path) -> List[Dict[str, Any]]:
+    """Load JSON from ``in_path`` and write cleaned list to ``out_path``.
+
+    The function converts binary string representations in the ``Ebene`` and
+    ``Gruppe`` fields to integers. It returns the cleaned list of dictionaries.
+    """
+    with in_path.open('r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    for entry in data:
+        if isinstance(entry, dict):
+            entry['Ebene'] = _decode_numeric_field(entry.get('Ebene'))
+            entry['Gruppe'] = _decode_numeric_field(entry.get('Gruppe'))
+
+    with out_path.open('w', encoding='utf-8') as f:
+        json.dump(data, f, ensure_ascii=False, indent=2)
+
+    return data
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Clean binary fields in PAUSCHALEN_Bedingungen")
+    parser.add_argument('input', type=Path, help='Input JSON path')
+    parser.add_argument('output', type=Path, help='Output JSON path')
+
+    args = parser.parse_args()
+    export_pauschalen_table(args.input, args.output)


### PR DESCRIPTION
## Summary
- add `export_pauschalen_table.py` to clean `Ebene` and `Gruppe` fields
- document optional export step in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_686401b951d4832394723a8bb8870c13