### PR TITLE
Fix context creation in analyze_billing

### DIFF
--- a/server.py
+++ b/server.py
@@ -890,9 +890,6 @@ def analyze_billing():
                 katalog_context_parts.append(
                     f"LKN: {lkn_code}, Typ: {details.get('Typ', 'N/A')}, Beschreibung: {html.escape(desc_de)}, MedizinischeInterpretation: {html.escape(med_de)}"
                 )
-                if mi_joined:
-                    context_line += f", MedizinischeInterpretation: {html.escape(mi_joined)}"
-                katalog_context_parts.append(context_line)
             if len(katalog_context_parts) >= 200:
                 break
         katalog_context_str = "\n".join(katalog_context_parts)


### PR DESCRIPTION
## Summary
- remove dangling variables from `analyze_billing`

## Testing
- `python run_quality_tests.py` *(fails: No module named 'flask')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6864f07fcf1c832390f3d05da62acb23