### PR TITLE
Improve synonym handling and prompt clarity

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -4,7 +4,7 @@ def get_stage1_prompt(user_input: str, katalog_context: str, lang: str) -> str:
     if lang == "fr":
         return f"""**Tâche :** Analyse avec précision le texte de traitement médical ci-dessous provenant de Suisse. Ta mission consiste à identifier les numéros du catalogue des prestations (LKN), à en déterminer la quantité et à extraire les informations contextuelles. Appuie-toi principalement sur le LKAAT_Leistungskatalog fourni, mais tu peux aussi tenir compte de synonymes médicaux courants ou de termes usuels et consulter la table des forfaits.
 
-**Contexte : LKAAT_Leistungskatalog (source de référence pour les LKN et leurs descriptions ; la table des forfaits peut également être prise en compte.)**
+**Contexte : LKAAT_Leistungskatalog (source de référence pour les LKN, leurs descriptions et les sections "MedizinischeInterpretation" où des synonymes peuvent apparaître ; la table des forfaits peut également être prise en compte.)
 --- Leistungskatalog Start ---
 {katalog_context}
 --- Leistungskatalog Ende ---
@@ -16,7 +16,8 @@ def get_stage1_prompt(user_input: str, katalog_context: str, lang: str) -> str:
     *   Identifie **tous** les codes LKN potentiels (format `XX.##.####`) pouvant représenter les actes décrits.
     *   Note que plusieurs prestations peuvent être documentées dans le texte et que plusieurs LKN peuvent être valides (p. ex. intervention chirurgicale plus anesthésie).
     *   Si une anesthésie ou une narcose réalisée par un anesthésiste est mentionnée, sélectionne explicitement un code du chapitre WA.10 (table ANAST). S'il n'est pas fait mention de la durée, utilise par défaut `WA.10.0010`. Lorsque la durée précise en minutes est indiquée, emploie le code `WA.10.00x0` approprié.
-    *   Mets à profit tes connaissances médicales sur les synonymes et termes techniques usuels (p. ex. reconnais que « opération de la cataracte » = « phacoémulsification » / « extraction du cristallin » = « Extractio lentis »).
+    *   Mets à profit tes connaissances médicales sur les synonymes et termes techniques usuels (p. ex. reconnais que « opération de la cataracte » = « phacoémulsification » / « extraction du cristallin » = « Extractio lentis ») et tiens aussi compte des formulations qui peuvent apparaître dans le champ "MedizinischeInterpretation".
+    *   Utilise également ton sens stylistique : « grand » peut signifier « complet », l'ordre des mots peut varier et les formes nominales et verbales peuvent être équivalentes (p. ex. « retrait » vs « retirer »).
     *   **ABSOLUMENT CRITIQUE:** Pour CHAQUE code LKN potentiel, vérifie **LETTRE PAR LETTRE et CHIFFRE PAR CHIFFRE** que ce code existe **EXACTEMENT** comme 'LKN:' dans le catalogue ci-dessus. Ce n'est que si le code existe que tu compares la **description du catalogue** avec l'acte décrit.
     *   Crée une liste (`identified_leistungen`) **UNIQUEMENT** avec les LKN ayant passé cette vérification exacte et dont la description correspond au texte.
     *   Reconnais si les prestations relèvent du chapitre CA (médecine de famille).
@@ -74,7 +75,7 @@ Réponse JSON:"""
     elif lang == "it":
         return f"""**Compito:** Analizza con la massima precisione il testo di trattamento medico seguente proveniente dalla Svizzera. Il tuo obiettivo è identificare i numeri di catalogo delle prestazioni (LKN), determinarne la quantità ed estrarre informazioni contestuali. Basati principalmente sul LKAAT_Leistungskatalog fornito, ma puoi utilizzare sinonimi medici o termini comuni e includere la tabella delle Pauschalen.
 
-**Contesto: LKAAT_Leistungskatalog (fonte principale per i LKN e le relative descrizioni; in aggiunta è disponibile la tabella delle Pauschalen.)**
+**Contesto: LKAAT_Leistungskatalog (fonte principale per i LKN, le relative descrizioni e le sezioni "MedizinischeInterpretation" con possibili sinonimi; in aggiunta è disponibile la tabella delle Pauschalen.)
 --- Leistungskatalog Start ---
 {katalog_context}
 --- Leistungskatalog Ende ---
@@ -86,7 +87,8 @@ Réponse JSON:"""
     *   Identifica **tutti** i possibili codici LKN (formato `XX.##.####`) che potrebbero rappresentare le attività descritte.
     *   Considera che nel testo possono essere documentate più prestazioni e quindi possono essere valide più LKN (ad es. intervento chirurgico più anestesia).
     *   Se viene menzionata un'anestesia o narcosi eseguita da un anestesista, seleziona esplicitamente un codice del capitolo WA.10 (tabella ANAST). Se non è indicata la durata, usa di default `WA.10.0010`. Quando viene fornita una durata precisa in minuti, impiega il corrispondente codice `WA.10.00x0`.
-    *   Sfrutta le tue conoscenze mediche su sinonimi e termini tecnici tipici (ad es. riconosci che « intervento di cataratta » = « facoemulsificazione » / « estrazione del cristallino » = « Extractio lentis »).
+    *   Sfrutta le tue conoscenze mediche su sinonimi e termini tecnici tipici (ad es. riconosci che « intervento di cataratta » = « facoemulsificazione » / « estrazione del cristallino » = « Extractio lentis ») e considera anche i termini che possono comparire nel campo "MedizinischeInterpretation".
+    *   Usa anche il tuo senso stilistico: "grande" può significare "esteso", l'ordine delle parole può variare e forme sostantivali e verbali possono avere lo stesso significato (es. "rimozione" vs "rimuovere").
     *   **ASSOLUTAMENTE CRITICO:** Per OGNI codice LKN potenziale verifica **LETTERA PER LETTERA e CIFRA PER CIFRA** che esista **ESATTAMENTE** come 'LKN:' nel catalogo sopra. Solo se il codice esiste confronta la **descrizione del catalogo** con l'attività descritta.
     *   Crea un elenco (`identified_leistungen`) **SOLO** con le LKN che hanno superato questa verifica esatta e la cui descrizione corrisponde al testo.
     *   Riconosci se si tratta di prestazioni di medicina di base del capitolo CA.
@@ -144,7 +146,7 @@ Risposta JSON:"""
     else:
         return f"""**Aufgabe:** Analysiere den folgenden medizinischen Behandlungstext aus der Schweiz äußerst präzise. Deine Aufgabe ist es, relevante Leistungs-Katalog-Nummern (LKN) samt Menge und Kontextinformationen zu bestimmen. Nutze primär den bereitgestellten LKAAT_Leistungskatalog, darfst aber auch medizinische Synonyme oder übliche Begriffe berücksichtigen und die Pauschalen-Tabelle hinzuziehen.
 
-**Kontext: LKAAT_Leistungskatalog (maßgebliche Quelle für gültige LKNs und deren Beschreibungen; ergänzend kann die Pauschalen-Tabelle verwendet werden.)**
+**Kontext: LKAAT_Leistungskatalog (maßgebliche Quelle für gültige LKNs, deren Beschreibungen und etwaige "MedizinischeInterpretation"-Abschnitte mit zusätzlichen Begriffen; ergänzend kann die Pauschalen-Tabelle verwendet werden.)
 --- Leistungskatalog Start ---
 {katalog_context}
 --- Leistungskatalog Ende ---
@@ -158,8 +160,8 @@ Risposta JSON:"""
     *   Wird eine Anästhesie oder Narkose durch einen Anästhesisten erwähnt, wähle ausdrücklich einen Code aus Kapitel WA.10 (Tabelle ANAST). Wenn keine Dauer angegeben ist, verwende standardmäßig `WA.10.0010`. Bei einer konkreten Dauerangabe in Minuten nutze den entsprechenden `WA.10.00x0`-Code.
     *   Nutze dein ausgeprägtes medizinisches und terminologisches Wissen zu **Synonymen und typischen Fachbegriffen** 
         (z.B. erkenne, dass "Kataraktoperation" = "Phakoemulsifikation"/"Linsenextraktion" = "Extractio lentis" 
-        oder dass "Herzkatheter"/"Linksherzkather" = "Koronarographie").
-    *   Nutze dein stilistisches Wissen und erkenne, dass beispielsweise "gross" auch "umfassend" bedeuten könnte oder dass Wörter in anderer Reihenfolge auftreten können.
+        oder dass "Herzkatheter"/"Linksherzkather" = "Koronarographie") und berücksichtige auch Formulierungen aus dem Feld "MedizinischeInterpretation".
+    *   Nutze dein stilistisches Wissen und erkenne, dass beispielsweise "gross" auch "umfassend" bedeuten kann, dass Wörter in anderer Reihenfolge stehen können und dass Substantiv- und Verbformen dieselbe Bedeutung haben können (z.B. "Entfernung" vs "entfernen").
     *   ABSOLUT KRITISCH: Für JEDEN potenziellen LKN-Code prüfe BUCHSTABE FÜR BUCHSTABE und ZIFFER FÜR ZIFFER, dass dieser Code EXAKT als „LKN:“ im obigen Katalog existiert. Nur wenn der Code existiert, vergleichst du die Katalogbeschreibung mit der beschriebenen Leistung.
     *   Erstelle eine Liste (`identified_leistungen`) **AUSSCHLIESSLICH** mit den LKNs, die diese **exakte** Prüfung im Katalog bestanden haben UND deren Beschreibung zum Text passt.
     *   Erkenne, ob es sich um hausärztliche Leistungen im Kapitel CA handelt.

--- a/tests/test_examples_synonyms.py
+++ b/tests/test_examples_synonyms.py
@@ -1,0 +1,67 @@
+import unittest
+from unittest.mock import patch
+import server
+
+
+class TestExampleSynonyms(unittest.TestCase):
+    def setUp(self):
+        server.app.config['TESTING'] = True
+
+    @patch('server.perform_analysis')
+    @patch('server.load_data', return_value=True)
+    def test_blinddarm_example(self, _, mock_perform):
+        mock_perform.return_value = {
+            'abrechnung': {
+                'type': 'Pauschale',
+                'details': {'Pauschale': 'C06.00A'},
+                'leistungen': []
+            }
+        }
+        with server.app.test_client() as client:
+            resp = client.post('/api/test-example', json={'id': 10, 'lang': 'de'})
+            self.assertEqual(resp.status_code, 200)
+            data = resp.get_json()
+            self.assertTrue(data.get('passed'))
+
+    @patch('server.perform_analysis')
+    @patch('server.load_data', return_value=True)
+    def test_rheuma_example(self, _, mock_perform):
+        mock_perform.return_value = {
+            'abrechnung': {
+                'type': 'TARDOC',
+                'leistungen': [
+                    {'lkn': 'AA.00.0010', 'menge': 1},
+                    {'lkn': 'AA.00.0020', 'menge': 15},
+                    {'lkn': 'KF.05.0050', 'menge': 1},
+                ]
+            }
+        }
+        with server.app.test_client() as client:
+            resp = client.post('/api/test-example', json={'id': 3, 'lang': 'de'})
+            self.assertEqual(resp.status_code, 200)
+            data = resp.get_json()
+            self.assertTrue(data.get('passed'))
+
+    @patch('server.perform_analysis')
+    @patch('server.load_data', return_value=True)
+    def test_warze_example(self, _, mock_perform):
+        mock_perform.return_value = {
+            'abrechnung': {
+                'type': 'TARDOC',
+                'leistungen': [
+                    {'lkn': 'AA.00.0010', 'menge': 1},
+                    {'lkn': 'AA.00.0020', 'menge': 5},
+                    {'lkn': 'MK.05.0070', 'menge': 5},
+                    {'lkn': 'AR.00.0030', 'menge': 1},
+                ]
+            }
+        }
+        with server.app.test_client() as client:
+            resp = client.post('/api/test-example', json={'id': 2, 'lang': 'de'})
+            self.assertEqual(resp.status_code, 200)
+            data = resp.get_json()
+            self.assertTrue(data.get('passed'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_extract_keywords.py
+++ b/tests/test_extract_keywords.py
@@ -1,0 +1,15 @@
+import unittest
+from utils import extract_keywords
+
+class TestExtractKeywords(unittest.TestCase):
+    def test_synonym_expansion_appendix(self):
+        tokens = extract_keywords("Blinddarmentfernung als alleinige Leistung")
+        self.assertIn("appendektomie", tokens)
+        self.assertIn("appendix", tokens)
+
+    def test_synonym_expansion_warze(self):
+        tokens = extract_keywords("Entfernung Warze mit dem scharfen L\xf6ffel")
+        self.assertIn("hyperkeratose", tokens)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -458,6 +458,20 @@ STOPWORDS: Set[str] = {
 }
 
 
+# Laienbegriffe und deren häufig verwendete Fachtermini zur Keyword-Erweiterung
+SYNONYM_MAP: Dict[str, List[str]] = {
+    "blinddarmentfernung": ["appendektomie", "appendix"],
+    "blinddarm": ["appendix"],
+    "warze": ["hyperkeratose"],
+    "warzen": ["hyperkeratosen"],
+    "gross": ["umfassend"],
+    "grosser": ["umfassender"],
+    "entfernung": ["entfernen"],
+    "entfernen": ["entfernung"],
+    "rheuma": ["rheumatologisch"],
+}
+
+
 def extract_keywords(text: str) -> Set[str]:
     """Return significant keywords from ``text``.
 
@@ -468,5 +482,10 @@ def extract_keywords(text: str) -> Set[str]:
 
     expanded = expand_compound_words(text)
     tokens = re.findall(r"\b\w+\b", expanded.lower())
-    return {t for t in tokens if len(t) >= 4 and t not in STOPWORDS}
+    base_tokens = {t for t in tokens if len(t) >= 4 and t not in STOPWORDS}
+    expanded_tokens = set(base_tokens)
+    for t in list(base_tokens):
+        for syn in SYNONYM_MAP.get(t, []):
+            expanded_tokens.add(syn.lower())
+    return expanded_tokens
 


### PR DESCRIPTION
## Summary
- expand keyword extraction with a small synonym map
- clarify Stage‑1 prompts to mention stylistic variations
- add unit tests for keyword synonym expansion

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_6864dcda8b008323b7d5507493bcaee4