### PR TITLE
Improve bidirectional synonym expansion

### DIFF
--- a/tests/test_extract_keywords.py
+++ b/tests/test_extract_keywords.py
@@ -11,5 +11,10 @@ class TestExtractKeywords(unittest.TestCase):
         tokens = extract_keywords("Entfernung Warze mit dem scharfen L\xf6ffel")
         self.assertIn("hyperkeratose", tokens)
 
+    def test_synonym_bidirectional_rheuma(self):
+        tokens_word = extract_keywords("rheuma")
+        tokens_phrase = extract_keywords("rheumatologische Untersuchung")
+        self.assertEqual(tokens_word, tokens_phrase)
+
 if __name__ == '__main__':
     unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -461,14 +461,21 @@ STOPWORDS: Set[str] = {
 # Laienbegriffe und deren häufig verwendete Fachtermini zur Keyword-Erweiterung
 SYNONYM_MAP: Dict[str, List[str]] = {
     "blinddarmentfernung": ["appendektomie", "appendix"],
+    "appendektomie": ["blinddarmentfernung"],
+    "appendix": ["blinddarmentfernung", "blinddarm"],
     "blinddarm": ["appendix"],
     "warze": ["hyperkeratose"],
+    "hyperkeratose": ["warze"],
     "warzen": ["hyperkeratosen"],
+    "hyperkeratosen": ["warzen"],
     "gross": ["umfassend"],
+    "umfassend": ["gross"],
     "grosser": ["umfassender"],
+    "umfassender": ["grosser"],
     "entfernung": ["entfernen"],
     "entfernen": ["entfernung"],
     "rheuma": ["rheumatologisch"],
+    "rheumatologisch": ["rheuma"],
 }
 
 
@@ -483,9 +490,23 @@ def extract_keywords(text: str) -> Set[str]:
     expanded = expand_compound_words(text)
     tokens = re.findall(r"\b\w+\b", expanded.lower())
     base_tokens = {t for t in tokens if len(t) >= 4 and t not in STOPWORDS}
-    expanded_tokens = set(base_tokens)
-    for t in list(base_tokens):
-        for syn in SYNONYM_MAP.get(t, []):
-            expanded_tokens.add(syn.lower())
+
+    def collect_synonyms(token: str) -> Set[str]:
+        """Return ``token`` and all synonyms recursively."""
+        collected = {token}
+        queue = [token]
+        while queue:
+            current = queue.pop()
+            for syn in SYNONYM_MAP.get(current, []):
+                syn = syn.lower()
+                if syn not in collected:
+                    collected.add(syn)
+                    queue.append(syn)
+        return collected
+
+    expanded_tokens: Set[str] = set()
+    for t in base_tokens:
+        expanded_tokens.update(collect_synonyms(t))
+
     return expanded_tokens
 


### PR DESCRIPTION
## Summary
- allow synonym lookup in both directions
- recursively expand keywords via synonyms
- verify that rheuma and rheumatologische Untersuchung produce identical keywords

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'flask')*

------
https://chatgpt.com/codex/tasks/task_e_68658614bf248323baddb48600ac9dee