### PR TITLE
Fix prefix detection for compound words

### DIFF
--- a/tests/test_expand_compound_words.py
+++ b/tests/test_expand_compound_words.py
@@ -1,0 +1,18 @@
+import unittest
+import sys
+import pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from utils import expand_compound_words
+
+class TestExpandCompoundWords(unittest.TestCase):
+    def test_linksherzkatheter_expands(self):
+        result = expand_compound_words("LinksHerzkatheter")
+        self.assertIn("links Herzkatheter", result)
+        self.assertIn("Herzkatheter", result)
+
+    def test_untersuchung_unchanged(self):
+        result = expand_compound_words("Untersuchung")
+        self.assertEqual(result, "Untersuchung")
+
+if __name__ == '__main__':
+    unittest.main()

--- a/utils.py
+++ b/utils.py
@@ -427,11 +427,21 @@ def expand_compound_words(text: str) -> str:
     for token in re.findall(r"\b\w+\b", text):
         lowered = token.lower()
         for pref in prefixes:
-            if lowered.startswith(pref) and len(lowered) > len(pref) + 2:
-                base = token[len(pref):]
-                additions.append(f"{pref} {base}")
-                additions.append(base)
-                break
+            # Only split if the token begins with the prefix and the following
+            # character is an uppercase letter (including German umlauts) or a
+            # hyphen. This avoids false positives such as "Untersuchung" for the
+            # prefix "unter" while still expanding valid compounds like
+            # "LinksHerzkatheter" or "Links-Herzkatheter".
+            if (
+                lowered.startswith(pref)
+                and len(lowered) > len(pref) + 2
+            ):
+                next_char = token[len(pref)] if len(token) > len(pref) else ""
+                if next_char.isupper() or next_char == "-":
+                    base = token[len(pref):]
+                    additions.append(f"{pref} {base}")
+                    additions.append(base)
+                    break
 
     if additions:
         return text + " " + " ".join(additions)


### PR DESCRIPTION
## Summary
- update `expand_compound_words` to only split prefixes when followed by uppercase or hyphen
- add tests covering `expand_compound_words`

## Testing
- `pytest tests/test_expand_compound_words.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'server')*

------
https://chatgpt.com/codex/tasks/task_e_68658606dcd883238a1693c1073a21f7