### PR TITLE
Fix Pylance issues and improve compound word expansion

### DIFF
--- a/server.py
+++ b/server.py
@@ -70,13 +70,13 @@ except ModuleNotFoundError:  # Minimal stubs for test environment
         def run(self, *a, **k):
             pass
 
-    Flask: Any = _DummyFlask
+    Flask = _DummyFlask
 
     def jsonify(obj: Any = None) -> Any:
         return obj
 
-    def send_from_directory(directory: str, path: str, **kwargs: Any) -> str:
-        return path
+    def send_from_directory(directory: os.PathLike[str] | str, path: os.PathLike[str] | str, **kwargs: Any) -> Any:
+        return str(path)
 
     class Request:
         is_json = False

--- a/utils.py
+++ b/utils.py
@@ -431,21 +431,15 @@ def expand_compound_words(text: str) -> str:
         if lowered in excluded_words:
             continue
         for pref in prefixes:
-            # Only split if the token begins with the prefix and the following
-            # character is an uppercase letter (including German umlauts) or a
-            # hyphen. This avoids false positives such as "Untersuchung" for the
-            # prefix "unter" while still expanding valid compounds like
-            # "LinksHerzkatheter" or "Links-Herzkatheter".
-            if (
-                lowered.startswith(pref)
-                and len(lowered) > len(pref) + 2
-            ):
-                next_char = token[len(pref)] if len(token) > len(pref) else ""
-                if next_char.isupper() or next_char == "-":
-                    base = token[len(pref):]
-                    additions.append(f"{pref} {base}")
-                    additions.append(base)
-                    break
+            # Split the token if it begins with one of the known prefixes and
+            # has enough characters left for a meaningful base word. The strict
+            # check for an uppercase letter after the prefix has been removed to
+            # also handle inputs like "Linksherzkatheter".
+            if lowered.startswith(pref) and len(lowered) > len(pref) + 2:
+                base = token[len(pref):]
+                additions.append(f"{pref} {base}")
+                additions.append(base)
+                break
 
     if additions:
         return text + " " + " ".join(additions)


### PR DESCRIPTION
## Summary
- match stub `send_from_directory` signature with Flask
- make `_DummyFlask` usable as a type in type hints
- expand words like `Linksherzkatheter` in `expand_compound_words`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68658e12bce48323ac086d384ec63ec8