### PR TITLE
Add extensive logging for Pauschalen quality control

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -41,9 +41,12 @@ def get_stage1_prompt(user_input: str, katalog_context: str, lang: str) -> str:
     *   **Général:** si `menge_allgemein` (Z) est extrait ET que la LKN n'est pas basée sur le temps ET `anzahl_prozeduren` est `null`, mets `menge` = Z.
     *   **Nombre spécifique de procédures:** si `anzahl_prozeduren` est extrait et se rapporte clairement à la LKN (p. ex. "deux injections"), mets `menge` = `anzahl_prozeduren`. Cela prime sur `menge_allgemein`.
     *   Assure-toi que `menge` >= 1.
+    *   Si une procédure requiert une « latéralité », alors pour « beidseits » (des deux côtés), saisis quantité = 2 ET « latéralité » = « beidseits ».
 
 5.  **Justification:**
     *   `begruendung_llm` courte indiquant pourquoi les LKN **validées** ont été choisies. Réfère-toi au texte et aux **descriptions du catalogue**.
+
+**Instruction spécifique pour les consultations :** Si le texte de traitement décrit une « consultation » générale ou un « entretien » avec une durée (p. ex. « consultation 15 minutes ») et qu'AUCUNE spécialité spécifique (comme « médecine de famille ») n'est mentionnée, alors priorise les codes de consultation généraux du chapitre AA (p. ex. `AA.00.0010` pour les 5 premières minutes et `AA.00.0020` pour chaque minute supplémentaire). Assure-toi que les quantités sont correctement calculées en fonction de la durée (p. ex. 15 minutes = 1x `AA.00.0010` + 10x `AA.00.0020`).
 
 **Format de sortie:** **UNIQUEMENT** du JSON valide, **AUCUN** autre texte.
 ```json
@@ -112,9 +115,12 @@ Réponse JSON:"""
     *   **Generale:** se `menge_allgemein` (Z) è stato estratto E la LKN non è basata sul tempo E `anzahl_prozeduren` è `null`, imposta `menge` = Z.
     *   **Numero specifico di procedure:** se `anzahl_prozeduren` è stato estratto e si riferisce chiaramente alla LKN (ad es. "due iniezioni"), imposta `menge` = `anzahl_prozeduren`. Questo prevale su `menge_allgemein`.
     *   Assicurati che `menge` >= 1.
+    *   Se una procedura richiede una "lateralità", allora per "beidseits" (entrambi i lati), imposta quantità = 2 E "lateralità" = "beidseits".
 
 5.  **Motivazione:**
     *   `begruendung_llm` breve sul perché le LKN **convalidate** sono state scelte. Fai riferimento al testo e alle **descrizioni del catalogo**.
+
+**Istruzione specifica per le consultazioni:** Se il testo del trattamento descrive una "consultazione" generale o un "colloquio" con una durata (ad es. "consultazione 15 minuti") e NON viene menzionata NESSUNA specializzazione specifica (come "medicina di famiglia"), allora dai priorità ai codici di consultazione generali del capitolo AA (ad es. `AA.00.0010` per i primi 5 minuti e `AA.00.0020` per ogni minuto successivo). Assicurati che le quantità siano calcolate correttamente in base alla durata (ad es. 15 minuti = 1x `AA.00.0010` + 10x `AA.00.0020`).
 
 **Formato di output:** **SOLO** JSON valido, **NESSUN** altro testo.
 ```json

--- a/quality.html
+++ b/quality.html
@@ -17,11 +17,12 @@
     <h1 id="qcHeader">Qualitätskontrolle</h1>
     <table id="exampleTable">
         <thead>
-            <tr><th>ID</th><th>Beispiel</th><th></th><th>Ergebnis</th></tr>
+            <tr><th>ID</th><th>Beispiel</th><th>Aktion</th><th>Ergebnis DE</th><th>Ergebnis FR</th><th>Ergebnis IT</th></tr>
         </thead>
         <tbody></tbody>
     </table>
     <button id="testAllBtn">Alle Beispiele testen</button>
+    <div id="overallSummary"></div>
 
     <script src="quality.js"></script>
 </body>

--- a/quality.js
+++ b/quality.js
@@ -21,41 +21,131 @@ function loadExamples(){
         .then(d=>{ examplesData=d; buildTable(); });
 }
 
+let totalTests = 0;
+let passedTests = 0;
+
 function buildTable(){
     const tbody = document.querySelector('#exampleTable tbody');
     if(!tbody || !examplesData.length) return;
     tbody.innerHTML='';
-    const t = qcTranslations[currentLang];
-    const shortKey = 'value_'+currentLang.toUpperCase();
-    const extKey = 'extendedValue_'+currentLang.toUpperCase();
-    for(let i=1;i<examplesData.length;i++){
+    const t = qcTranslations[currentLang]; // For button text, example text uses specific lang
+
+    for(let i=1;i<examplesData.length;i++){ // Assuming example 0 is header or metadata
         const ex=examplesData[i];
-        const text=ex[extKey]||ex[shortKey]||'';
+        // Try to get example text in current language, fallback to DE, then first available
+        const exampleTextKey = 'value_' + currentLang.toUpperCase();
+        const exampleTextKeyExtended = 'extendedValue_' + currentLang.toUpperCase();
+        let text = ex[exampleTextKeyExtended] || ex[exampleTextKey] || ex['extendedValue_DE'] || ex['value_DE'] || '';
+        if (!text) { // Fallback to first available text if DE is also empty
+            const firstValKey = Object.keys(ex).find(k => k.startsWith('value_') || k.startsWith('extendedValue_'));
+            if (firstValKey) text = ex[firstValKey];
+        }
+
         const tr=document.createElement('tr');
-        tr.innerHTML=`<td>${i}</td><td>${text}</td><td><button class="single-test" data-id="${i}">${t.testExample}</button></td><td id="res-${i}"></td>`;
+        tr.setAttribute('data-example-id', i);
+        tr.innerHTML=`<td>${i}</td>
+                      <td>${text}</td>
+                      <td><button class="single-test-all-langs" data-id="${i}">${t.testExample}</button></td>
+                      <td id="res-${i}-de"></td>
+                      <td id="res-${i}-fr"></td>
+                      <td id="res-${i}-it"></td>`;
         tbody.appendChild(tr);
     }
-    document.querySelectorAll('.single-test').forEach(btn=>btn.addEventListener('click',()=>runTest(btn.dataset.id)));
+    document.querySelectorAll('.single-test-all-langs').forEach(btn => {
+        btn.addEventListener('click', () => runTestsForRow(btn.dataset.id));
+    });
+    updateOverallSummary();
 }
 
-function runTest(id){
-    fetch('/api/test-example', {method:'POST', headers:{'Content-Type':'application/json'}, body:JSON.stringify({id:parseInt(id), lang: currentLang})})
-        .then(r=>r.json()).then(res=>{
-            const cell = document.getElementById('res-'+id);
-            if(!cell) return;
-            if(res.passed){
-                cell.textContent = qcTranslations[currentLang].pass;
-            }else{
-                cell.textContent = qcTranslations[currentLang].fail + (res.diff ? ': '+res.diff : '');
+function runTest(id, lang) {
+    return new Promise((resolve) => {
+        const exampleId = parseInt(id);
+        fetch('/api/test-example', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: exampleId, lang: lang })
+        })
+        .then(r => {
+            if (!r.ok) {
+                throw new Error(`HTTP error ${r.status}`);
             }
-        }).catch(()=>{
-            const cell=document.getElementById('res-'+id);
-            if(cell) cell.textContent='error';
+            return r.json();
+        })
+        .then(res => {
+            const cell = document.getElementById(`res-${id}-${lang}`);
+            if (!cell) {
+                resolve({ id, lang, passed: false, error: 'Cell not found' });
+                return;
+            }
+            if (res.passed) {
+                cell.textContent = qcTranslations[currentLang].pass;
+                cell.style.color = 'green';
+                resolve({ id, lang, passed: true });
+            } else {
+                cell.textContent = qcTranslations[currentLang].fail + (res.diff ? ': ' + res.diff : '');
+                cell.style.color = 'red';
+                resolve({ id, lang, passed: false, diff: res.diff });
+            }
+        })
+        .catch(error => {
+            const cell = document.getElementById(`res-${id}-${lang}`);
+            if (cell) {
+                cell.textContent = 'error';
+                cell.style.color = 'orange';
+            }
+            console.error(`Error testing example ${id} lang ${lang}:`, error);
+            resolve({ id, lang, passed: false, error: error.message });
         });
+    });
 }
 
-function testAll(){
-    for(let i=1;i<examplesData.length;i++) runTest(i);
+async function runTestsForRow(id) {
+    // Clear previous results for this row
+    document.getElementById(`res-${id}-de`).textContent = '...';
+    document.getElementById(`res-${id}-fr`).textContent = '...';
+    document.getElementById(`res-${id}-it`).textContent = '...';
+
+    const langs = ['de', 'fr', 'it'];
+    for (const lang of langs) {
+        await runTest(id, lang); // Wait for each test to complete before starting the next
+    }
+    // Note: Overall summary is not updated per row, only for testAll
+}
+
+async function testAll() {
+    totalTests = 0;
+    passedTests = 0;
+    const testPromises = [];
+    // examplesData[0] is often metadata or headers, actual examples start from index 1
+    // or ensure examplesData is filtered to only contain actual examples.
+    // Assuming examplesData[0] might be an issue if it's not a valid example.
+    // Let's iterate from 1, or adjust if examplesData is 0-indexed for actual examples.
+    const numExamples = examplesData.length -1; // if examples start from 1
+    totalTests = numExamples * 3; // DE, FR, IT for each example
+
+    for (let i = 1; i < examplesData.length; i++) {
+        const exampleId = i; // Or examplesData[i].id if available and more robust
+        document.getElementById(`res-${exampleId}-de`).textContent = '...';
+        document.getElementById(`res-${exampleId}-fr`).textContent = '...';
+        document.getElementById(`res-${exampleId}-it`).textContent = '...';
+
+        testPromises.push(runTest(exampleId, 'de'));
+        testPromises.push(runTest(exampleId, 'fr'));
+        testPromises.push(runTest(exampleId, 'it'));
+    }
+
+    const results = await Promise.all(testPromises);
+    passedTests = results.filter(r => r.passed).length;
+    updateOverallSummary();
+}
+
+function updateOverallSummary() {
+    const summaryDiv = document.getElementById('overallSummary');
+    if (totalTests > 0) {
+        summaryDiv.textContent = `Gesamt: ${passedTests} / ${totalTests} bestanden.`;
+    } else {
+        summaryDiv.textContent = '';
+    }
 }
 
 document.getElementById('testAllBtn').addEventListener('click', testAll);

--- a/run_quality_tests.py
+++ b/run_quality_tests.py
@@ -1,8 +1,12 @@
 import json
 from pathlib import Path
 from typing import List
+from dotenv import load_dotenv
 
-from server import app, load_data
+# Load environment variables from .env file at the very beginning
+load_dotenv()
+
+from server import app
 
 BASELINE_PATH = Path(__file__).resolve().parent / "data" / "baseline_results.json"
 
@@ -13,8 +17,11 @@ def run_tests() -> None:
     with BASELINE_PATH.open("r", encoding="utf-8") as f:
         baseline_data = json.load(f)
 
-    if not load_data():
-        print("Fehler: Daten konnten nicht geladen werden.")
+    # Daten sollten durch den Import von server (und damit create_app) bereits geladen sein.
+    # Überprüfe hier den Status von daten_geladen aus dem server Modul.
+    from server import daten_geladen as server_daten_geladen
+    if not server_daten_geladen:
+        print("Fehler: Server-Daten wurden nicht korrekt initialisiert. Tests können nicht ausgeführt werden.")
         return
 
     results: List[bool] = []


### PR DESCRIPTION
- Add detailed logging to server.py in analyze_billing and call_gemini_stage1 to trace data state and API key availability.
- Modify run_quality_tests.py to explicitly use dotenv and check for server data readiness.
- Adjust quality.html and quality.js for multi-language (DE, FR, IT) result display in the quality assurance frontend.
- Update prompts.py to align FR/IT stage 1 prompts with DE version regarding consultation and bilaterality quantity adjustments.

Note: Tests in CI are still failing due to missing GEMINI_API_KEY. User will test locally with API key configured.