### PR TITLE
Add debug flag to structured condition evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Dies ist ein Prototyp einer Webanwendung zur Unterstützung bei der Abrechnung m
   `GruppenOperator` (Standard `UND`, einstellbar über
   `DEFAULT_GROUP_OPERATOR` in `regelpruefer_pauschale.py`) für die Verknüpfung
   der Bedingungsgruppen.
+- Optional kann ein `debug`-Flag genutzt werden, um die pro Gruppe erzeugten
+  Booleschen Ausdrücke samt Ergebnis auszugeben.
 - Die mehrsprachigen Prompts für LLM Stufe 1 und Stufe wurden in  `prompts.py` ausgelagert
 - Funktionale Erweiterung umfassen:
     - interaktive Info-Pop-ups, 
@@ -67,6 +69,7 @@ Der Assistent ist in den drei Landessprachen DE, FR und IT verfügbar. Die Sprac
           2. `ANZAHL >= 2`  (Operator `UND`)
           3. `LKN IN LISTE OP`
           der Ausdruck `(SEITIGKEIT = B ODER ANZAHL >= 2) UND LKN IN LISTE OP` ableiten. Berücksichtigt wird zudem das `useIcd`-Flag.
+        *   Bei gesetztem `debug=True` gibt die Funktion die pro Gruppe generierten Booleschen Ausdrücke samt Ergebnis aus.
         *   **Auswahl der besten Pauschale (`determine_applicable_pauschale`):** Wählt aus den struktur-gültigen Pauschalen die "komplexeste passende" (niedrigster Suffix-Buchstabe, z.B. A vor B vor E) aus der bevorzugten Kategorie (spezifisch vor Fallback).
         *   Generiert detailliertes HTML für die Bedingungsprüfung und eine Begründung der Auswahl.
     *   **Entscheidung & TARDOC-Vorbereitung:** Entscheidet "Pauschale vor TARDOC". Wenn keine Pauschale anwendbar ist, bereitet es die TARDOC-Liste (`regelpruefer.prepare_tardoc_abrechnung`) vor.

--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -224,12 +224,15 @@ def evaluate_structured_conditions(
     pauschale_bedingungen_data: List[Dict],
     tabellen_dict_by_table: Dict[str, List[Dict]],
     group_operator: str = DEFAULT_GROUP_OPERATOR,  # Dieser Operator gilt ZWISCHEN den Gruppen
+    debug: bool = False,
 ) -> bool:
     """
     Bewertet die Bedingungen einer Pauschale.
     Bedingungen werden zuerst nach 'Gruppe' gruppiert.
     Innerhalb jeder Gruppe wird die Logik basierend auf 'Ebene' und 'Operator' ausgewertet.
     Die Ergebnisse der Gruppen werden dann mit dem globalen 'group_operator' verknüpft.
+    Wenn ``debug`` ``True`` ist, wird für jede Gruppe der zusammengesetzte
+    Boolesche Ausdruck inklusive Ergebnis ausgegeben.
     """
     PAUSCHALE_KEY = 'Pauschale'
     GRUPPE_KEY = 'Gruppe'
@@ -332,6 +335,10 @@ def evaluate_structured_conditions(
         try:
             group_result_this_group = bool(eval(expr_str_group))
             group_results_bool.append(group_result_this_group)
+            if debug:
+                print(
+                    f"DEBUG Gruppe {group_id}: {expr_str_group} => {group_result_this_group}"
+                )
         except Exception as e_eval_group:
             print(f"FEHLER bei Gruppenlogik-Ausdruck (Pauschale: {pauschale_code}, Gruppe: {group_id}) '{expr_str_group}': {e_eval_group}")
             traceback.print_exc()
@@ -345,9 +352,16 @@ def evaluate_structured_conditions(
 
     # Verknüpfe die Ergebnisse der einzelnen Gruppen mit dem globalen group_operator
     if group_operator.upper() == "ODER":
-        return any(group_results_bool)
+        final_result = any(group_results_bool)
     else:  # "UND"
-        return all(group_results_bool)
+        final_result = all(group_results_bool)
+
+    if debug:
+        print(
+            f"DEBUG Ergebnis Pauschale {pauschale_code}: {group_results_bool} -> {final_result}"
+        )
+
+    return final_result
 
 # === FUNKTION ZUR HTML-GENERIERUNG DER BEDINGUNGSPRÜFUNG ===
 def check_pauschale_conditions(

--- a/tests/test_pauschale_logic.py
+++ b/tests/test_pauschale_logic.py
@@ -104,7 +104,7 @@ class TestPauschaleLogic(unittest.TestCase):
         # Bei strikter Links-nach-rechts-Auswertung muss auch die letzte
         # Bedingung erfüllt sein, da sie mit UND verknüpft wird.
         self.assertFalse(
-            evaluate_structured_conditions("CAT", context, conditions, {})
+            evaluate_structured_conditions("CAT", context, conditions, {}, debug=True)
         )
     @unittest.skip("Known issue")
 
@@ -221,7 +221,7 @@ class TestPauschaleLogic(unittest.TestCase):
 
         self.assertTrue(
             evaluate_structured_conditions(
-                "C04.51B", context_ok, bedingungen, tab_dict, group_operator="UND"
+                "C04.51B", context_ok, bedingungen, tab_dict, group_operator="UND", debug=True
             )
         )
 
@@ -231,7 +231,7 @@ class TestPauschaleLogic(unittest.TestCase):
         }
 
         self.assertTrue(
-            evaluate_structured_conditions("C04.51B", context_missing_lavage, bedingungen, tab_dict)
+            evaluate_structured_conditions("C04.51B", context_missing_lavage, bedingungen, tab_dict, debug=True)
         )
 
     def test_nested_levels(self):
@@ -268,12 +268,12 @@ class TestPauschaleLogic(unittest.TestCase):
 
         context_ok = {"LKN": ["B", "C"]}
         self.assertTrue(
-            evaluate_structured_conditions("NEST", context_ok, conditions, {})
+            evaluate_structured_conditions("NEST", context_ok, conditions, {}, debug=True)
         )
 
         context_missing_c = {"LKN": ["B"]}
         self.assertFalse(
-            evaluate_structured_conditions("NEST", context_missing_c, conditions, {})
+            evaluate_structured_conditions("NEST", context_missing_c, conditions, {}, debug=True)
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add optional `debug` parameter to `evaluate_structured_conditions`
- print boolean expressions per group when debugging
- update tests to show debug output for complex cases
- document the debug flag in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d3991a42883239cef61d7fc615014