### PR TITLE
Refine group operator heuristic

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ Dies ist ein Prototyp einer Webanwendung zur Unterstützung bei der Abrechnung m
 - `evaluate_structured_conditions` unterstützt einen konfigurierbaren
   `GruppenOperator` (Standard `UND`, einstellbar über
   `DEFAULT_GROUP_OPERATOR` in `regelpruefer_pauschale.py`) für die Verknüpfung
-  der Bedingungsgruppen.
+  der Bedingungsgruppen. Fehlt diese Spalte, wird der Operator heuristisch
+  bestimmt: Wenn mehrere Gruppen vorhanden sind und in der ersten Gruppe
+  mindestens eine Zeile den Operator `ODER` nutzt, gilt `ODER` global.
 - Die mehrsprachigen Prompts für LLM Stufe 1 und Stufe wurden in  `prompts.py` ausgelagert
 - Funktionale Erweiterung umfassen:
     - interaktive Info-Pop-ups, 

--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -199,20 +199,24 @@ def get_group_operator_for_pauschale(
                 return op
 
     # Heuristik: Wenn keine explizite Angabe vorhanden ist, aber mehrere Gruppen
-    # existieren und die erste Gruppe mit "ODER" beginnt, werten wir dies als
-    # globalen Gruppenoperator "ODER".
-    first_operator = None
+    # existieren und in der ersten Gruppe mindestens eine Zeile mit "ODER"
+    # verknüpft ist, werten wir dies als globalen Gruppenoperator "ODER".
+    first_group_id = None
     groups_seen: List[Any] = []
+    first_group_has_oder = False
     for cond in bedingungen_data:
         if cond.get("Pauschale") != pauschale_code:
             continue
         grp = cond.get("Gruppe")
+        if first_group_id is None:
+            first_group_id = grp
         if grp not in groups_seen:
             groups_seen.append(grp)
-            if first_operator is None:
-                first_operator = str(cond.get("Operator", "")).strip().upper()
+        if grp == first_group_id:
+            if str(cond.get("Operator", "")).strip().upper() == "ODER":
+                first_group_has_oder = True
 
-    if len(groups_seen) > 1 and first_operator == "ODER":
+    if len(groups_seen) > 1 and first_group_has_oder:
         return "ODER"
 
     return default

--- a/tests/test_pauschale_logic.py
+++ b/tests/test_pauschale_logic.py
@@ -3,7 +3,11 @@ import sys
 import pathlib
 import json
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
-from regelpruefer_pauschale import evaluate_structured_conditions, DEFAULT_GROUP_OPERATOR
+from regelpruefer_pauschale import (
+    evaluate_structured_conditions,
+    DEFAULT_GROUP_OPERATOR,
+    get_group_operator_for_pauschale,
+)
 
 class TestPauschaleLogic(unittest.TestCase):
     def test_or_operator_in_group(self):
@@ -274,6 +278,18 @@ class TestPauschaleLogic(unittest.TestCase):
         context_missing_c = {"LKN": ["B"]}
         self.assertFalse(
             evaluate_structured_conditions("NEST", context_missing_c, conditions, {})
+        )
+
+    def test_infer_group_operator_from_first_group_rows(self):
+        """If any row in the first group uses ODER and multiple groups exist, ODER is used globally."""
+        conditions = [
+            {"Pauschale": "HX", "Gruppe": 1, "Operator": "UND"},
+            {"Pauschale": "HX", "Gruppe": 1, "Operator": "ODER"},
+            {"Pauschale": "HX", "Gruppe": 2, "Operator": "UND"},
+        ]
+        self.assertEqual(
+            "ODER",
+            get_group_operator_for_pauschale("HX", conditions, default=DEFAULT_GROUP_OPERATOR),
         )
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- infer the global group operator from all rows of the first group
- document the new heuristic in the README
- test the refined operator detection

## Testing
- `python -m unittest tests.test_pauschale_logic -v`
- `python -m unittest tests.test_expand_compound_words -v`
- `python -m unittest tests.test_ranking_logic -v`
- `python -m unittest tests.test_extract_keywords -v`
- `python -m unittest tests.test_examples_synonyms -v`
- `python -m unittest tests.test_quality_endpoint -v`
- `python -m unittest tests.test_analyze_billing_endpoint -v`

------
https://chatgpt.com/codex/tasks/task_e_686d3989a798832396be5d76a4182ca9