### PR TITLE
Streamline Flask check in tests

### DIFF
--- a/tests/test_analyze_billing_endpoint.py
+++ b/tests/test_analyze_billing_endpoint.py
@@ -1,24 +1,17 @@
 import unittest
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import patch
 import sys
 import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 try:
     import flask  # noqa: F401
-    from flask import Flask
     FLASK_AVAILABLE = True
 except Exception:  # pragma: no cover - if Flask missing
     FLASK_AVAILABLE = False
-    server = None
 
-# Force FLASK_AVAILABLE to True for testing purposes
-FLASK_AVAILABLE = True
-
-if FLASK_AVAILABLE:
-    import server
+import server
 
 @unittest.skipUnless(FLASK_AVAILABLE, "Flask not installed")
 

--- a/tests/test_examples_synonyms.py
+++ b/tests/test_examples_synonyms.py
@@ -1,9 +1,8 @@
 import unittest
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import patch
 import sys
 import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 try:
@@ -11,10 +10,8 @@ try:
     FLASK_AVAILABLE = True
 except Exception:  # pragma: no cover - if Flask missing
     FLASK_AVAILABLE = False
-    server = None
 
-if FLASK_AVAILABLE:
-    import server
+import server
 
 @unittest.skipUnless(FLASK_AVAILABLE, "Flask not installed")
 class TestExampleSynonyms(unittest.TestCase):

--- a/tests/test_quality_endpoint.py
+++ b/tests/test_quality_endpoint.py
@@ -1,9 +1,8 @@
 import unittest
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 from unittest.mock import patch
 import sys
 import pathlib
+
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 try:
@@ -11,10 +10,8 @@ try:
     FLASK_AVAILABLE = True
 except Exception:  # pragma: no cover - if Flask missing
     FLASK_AVAILABLE = False
-    server = None
 
-if FLASK_AVAILABLE:
-    import server
+import server
 @unittest.skipUnless(FLASK_AVAILABLE, "Flask not installed")
 
 class TestQualityEndpoint(unittest.TestCase):


### PR DESCRIPTION
## Summary
- simplify Flask detection logic in tests
- skip Flask-dependent tests when Flask isn't installed
- remove duplicate imports across several tests

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d62df1e64832389fc9e9b8fff7e03