### PR TITLE
Add logic recomposition helper and tests

### DIFF
--- a/tests/recompose_logic.py
+++ b/tests/recompose_logic.py
@@ -1,0 +1,46 @@
+import json
+from pathlib import Path
+from typing import Dict, List
+
+
+def recompose_logic(path: Path) -> Dict[str, str]:
+    """Return a mapping of pauschalen codes to reconstructed logic strings."""
+    with path.open(encoding="utf-8") as f:
+        data = json.load(f)
+
+    by_pauschale: Dict[str, List[dict]] = {}
+    for row in data:
+        code = row.get("Pauschale")
+        if code is None:
+            continue
+        by_pauschale.setdefault(code, []).append(row)
+
+    result: Dict[str, str] = {}
+    for code, conds in by_pauschale.items():
+        filtered = [c for c in conds if c.get("Bedingungstyp") != "AST VERBINDUNGSOPERATOR"]
+        filtered.sort(key=lambda c: c.get("BedingungsID", 0))
+        if not filtered:
+            result[code] = ""
+            continue
+
+        baseline = 1
+        first_level = filtered[0].get("Ebene", baseline)
+        expr_parts: List[str] = ["(" * (first_level - baseline), str(filtered[0]["BedingungsID"])]
+        prev_level = first_level
+        prev_op = filtered[0].get("Operator", "UND").upper()
+
+        for cond in filtered[1:]:
+            level = cond.get("Ebene", baseline)
+            if level < prev_level:
+                expr_parts.append(")" * (prev_level - level))
+            expr_parts.append(" AND " if prev_op == "UND" else " OR ")
+            if level > prev_level:
+                expr_parts.append("(" * (level - prev_level))
+            expr_parts.append(str(cond["BedingungsID"]))
+            prev_level = level
+            prev_op = cond.get("Operator", "UND").upper()
+
+        expr_parts.append(")" * (prev_level - baseline))
+        result[code] = "".join(expr_parts)
+
+    return result

--- a/tests/test_recompose_logic.py
+++ b/tests/test_recompose_logic.py
@@ -1,0 +1,19 @@
+import unittest
+import pathlib
+from recompose_logic import recompose_logic
+
+class TestRecomposeLogic(unittest.TestCase):
+    def setUp(self):
+        root = pathlib.Path(__file__).resolve().parents[1]
+        self.expressions = recompose_logic(root / "data/PAUSCHALEN_Bedingungen.json")
+
+    def test_c00_10a_logic(self):
+        expected = "(((1)) OR 2 AND (3 AND 4 AND 5) AND 6 AND (7 AND 8 AND 9) AND 10 AND 11 AND 12 OR (13 AND 14))"
+        self.assertEqual(self.expressions.get("C00.10A"), expected)
+
+    def test_c00_10b_logic(self):
+        expected = "(((1)) OR 2 AND (3 AND 4 AND 5) AND 6 AND (7 AND 8 AND 9) AND 10 AND 11 AND 12)"
+        self.assertEqual(self.expressions.get("C00.10B"), expected)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- implement `recompose_logic` to rebuild boolean expressions from `PAUSCHALEN_Bedingungen.json`
- add unit tests for sample pauschalen

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d62b75c5483238cbe7398dec2102c