### PR TITLE
Improve pauschale ranking using scores

### DIFF
--- a/tests/test_pauschale_logic.py
+++ b/tests/test_pauschale_logic.py
@@ -369,5 +369,18 @@ class TestPauschaleLogic(unittest.TestCase):
             evaluate_structured_conditions("ALT", context_fail, conditions, {})
         )
 
+    def test_score_based_selection(self):
+        """Higher scoring Pauschale should be chosen even if suffix later."""
+        from regelpruefer_pauschale import determine_applicable_pauschale
+
+        pauschalen_dict = {
+            "X00.01A": {"Pauschale": "X00.01A", "Pauschale_Text": "A", "Taxpunkte": "100"},
+            "X00.01B": {"Pauschale": "X00.01B", "Pauschale_Text": "B", "Taxpunkte": "200"},
+        }
+        result = determine_applicable_pauschale(
+            "", [], {}, [], [], pauschalen_dict, {}, {}, {"X00.01A", "X00.01B"}
+        )
+        self.assertEqual(result["details"]["Pauschale"], "X00.01B")
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- select Pauschale by score instead of alphabetical suffix
- add regression test verifying higher scoring Pauschale wins

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6aa3ab7c83238cf3f1d7ae2a5f93