### PR TITLE
Use logging instead of prints

### DIFF
--- a/run_quality_tests.py
+++ b/run_quality_tests.py
@@ -1,7 +1,10 @@
 import json
+import logging
 from pathlib import Path
 from typing import List
 from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
 
 # Load environment variables from .env file at the very beginning
 load_dotenv()
@@ -21,7 +24,9 @@ def run_tests() -> None:
     # Überprüfe hier den Status von daten_geladen aus dem server Modul.
     from server import daten_geladen as server_daten_geladen
     if not server_daten_geladen:
-        print("Fehler: Server-Daten wurden nicht korrekt initialisiert. Tests können nicht ausgeführt werden.")
+        logger.error(
+            "Fehler: Server-Daten wurden nicht korrekt initialisiert. Tests können nicht ausgeführt werden."
+        )
         return
 
     results: List[bool] = []
@@ -35,7 +40,12 @@ def run_tests() -> None:
                     json={"id": int(ex_id), "lang": lang},
                 )
                 if resp.status_code != 200:
-                    print(f"Beispiel {ex_id} [{lang}] Fehler: HTTP {resp.status_code}")
+                    logger.error(
+                        "Beispiel %s [%s] Fehler: HTTP %s",
+                        ex_id,
+                        lang,
+                        resp.status_code,
+                    )
                     results.append(False)
                     continue
 
@@ -43,12 +53,18 @@ def run_tests() -> None:
                 passed = bool(data.get("passed"))
                 diff = data.get("diff", "")
                 status = "PASS" if passed else "FAIL"
-                print(f"Beispiel {ex_id} [{lang}]: {status}{' - ' + diff if diff else ''}")
+                logger.info(
+                    "Beispiel %s [%s]: %s%s",
+                    ex_id,
+                    lang,
+                    status,
+                    f" - {diff}" if diff else "",
+                )
                 results.append(passed)
 
     total = len(results)
     passed_count = sum(1 for r in results if r)
-    print(f"\n{passed_count}/{total} Tests bestanden.")
+    logger.info("\n%s/%s Tests bestanden.", passed_count, total)
 
 
 if __name__ == "__main__":

--- a/utils.py
+++ b/utils.py
@@ -1,7 +1,10 @@
 # utils.py
 import html
+import logging
 from typing import Dict, List, Any, Set
 import re
+
+logger = logging.getLogger(__name__)
 
 def escape(text: Any) -> str:
     """Escapes HTML special characters in a string."""
@@ -31,7 +34,11 @@ def get_table_content(table_ref: str, table_type: str, tabellen_dict_by_table: d
                     if code:
                         all_entries_for_type.append({"Code": code, "Code_Text": text or "N/A"})
         else:
-             print(f"WARNUNG (get_table_content): Normalisierter Schlüssel '{normalized_key}' (Original: '{name}') nicht in tabellen_dict_by_table gefunden.")
+            logger.warning(
+                "WARNUNG (get_table_content): Normalisierter Schlüssel '%s' (Original: '%s') nicht in tabellen_dict_by_table gefunden.",
+                normalized_key,
+                name,
+            )
 
     unique_content = {item['Code']: item for item in all_entries_for_type}.values()
     return sorted(unique_content, key=lambda x: x.get('Code', ''))


### PR DESCRIPTION
## Summary
- add module-level loggers to backend scripts
- swap print statements for logger calls throughout the codebase

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d6eebc1588323934548fcb9df17a3