### PR TITLE
I've implemented multi-level, resizable, and draggable pop-up windows.

### DIFF
--- a/index.html
+++ b/index.html
@@ -320,6 +320,8 @@
             z-index: 10000;
             padding-top: 5vh; /* Etwas Abstand von oben */
         }
+        #infoModalDetailOverlay { z-index: 10010; }
+        #infoModalNestedOverlay { z-index: 10020; }
         .info-modal {
             background: var(--background-color);
             padding: 25px;
@@ -328,11 +330,18 @@
             min-width: 300px;
             margin-left: 5vw; /* Linksbündig mit etwas Abstand */
             max-height: 85vh;
-            overflow-y: auto;
+            overflow: auto; /* Geändert von overflow-y für resize */
+            resize: both; /* Größenänderung erlauben */
             border-radius: 6px;
             box-shadow: 0 4px 15px rgba(0,0,0,0.35);
             border: 1px solid var(--primary);
             position: relative;
+        }
+        .info-modal-nested {
+            width: 60vw; /* Etwas kleiner */
+            max-width: 800px;
+            margin-left: 8vw; /* Leicht versetzt */
+            margin-top: 3vh; /* Leicht versetzt */
         }
         .info-modal h2, .info-modal h3 {
             color: var(--primary);
@@ -427,6 +436,14 @@
         <div id="infoModalDetail" class="info-modal info-modal-detail"> <!-- Added info-modal-detail for potential specific styling -->
             <button id="infoModalDetailClose" class="modal-close">&times;</button>
             <div id="infoModalDetailContent"></div>
+        </div>
+    </div>
+
+    <!-- Nested (second level) Detail Info Modal -->
+    <div id="infoModalNestedOverlay" class="info-modal-overlay" style="display:none;">
+        <div id="infoModalNested" class="info-modal info-modal-nested">
+            <button id="infoModalNestedClose" class="modal-close">&times;</button>
+            <div id="infoModalNestedContent"></div>
         </div>
     </div>
 


### PR DESCRIPTION
This commit introduces the following features to the pop-up modal windows:

1.  **Multi-Level Pop-ups**: Clicking a link within an existing pop-up now opens a new, smaller, and slightly offset pop-up on top of the first one. This allows for nested information display.

2.  **Resizable and Draggable**: All pop-up windows can now be resized using a handle in the bottom-right corner and can be moved around the screen by dragging them.

3.  **Independent Closing**: The top-most pop-up can be closed without affecting the one(s) underneath it.

4.  **ESC Key Functionality**: Pressing the 'Escape' key now closes the top-most visible pop-up window.

These changes were implemented by:
- Adding a third modal structure to `index.html`.
- Updating CSS to handle resizing, z-index stacking, and positioning.
- Enhancing the JavaScript logic in `calculator.js` to manage the new modal level, handle events correctly, and implement the ESC key listener.