### PR TITLE
Fix memory use and update worker settings

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn server:app
+web: gunicorn server:app --timeout 120 --workers 1

--- a/README.md
+++ b/README.md
@@ -159,14 +159,14 @@ Der Assistent ist in den drei Landessprachen DE, FR und IT verfügbar. Die Sprac
     *   Stelle sicher, dass `requirements.txt` existiert und `Flask`, `requests`, `python-dotenv`, `gunicorn` enthält.
     *   Erstelle eine `Procfile`-Datei im Stammverzeichnis:
         ```
-        web: gunicorn server:app --timeout 120
+        web: gunicorn server:app --timeout 120 --workers 1
         ```
     *   Initialisiere Git LFS im Repository, falls noch nicht geschehen (`git lfs install`), und verfolge die JSON-Dateien im `data`-Ordner (`git lfs track "data/*.json"`). Committe `.gitattributes` und die Pointer-Dateien.
     *   Stelle sicher, dass `.env` in `.gitignore` ist.
 2.  **Render.com Setup:**
     *   Erstelle einen neuen "Web Service" auf Render.com und verbinde dein Git-Repository.
     *   **Build Command:** `pip install -r requirements.txt`
-    *   **Start Command:** `gunicorn server:app --timeout 120`
+    *   **Start Command:** `gunicorn server:app --timeout 120 --workers 1`
     *   **Environment Variables:** Setze `GEMINI_API_KEY` (und optional `PYTHON_VERSION`, `GEMINI_MODEL`) im Render.com Dashboard.
 3.  **Deployment:** Pushe deine Änderungen. Render.com sollte automatisch deployen und Git LFS-Dateien korrekt behandeln.
 

--- a/regelpruefer_pauschale.py
+++ b/regelpruefer_pauschale.py
@@ -561,12 +561,12 @@ def evaluate_pauschale_logic_orchestrator(
     an AST operator, they are connected based on the 'Operator' field of the last
     condition of the preceding group (UND if 'UND', otherwise ODER).
     """
-    # Filter conditions for the current pauschale and sort them by BedingungsID
-    # This sorting is crucial for correct sequential processing of defined logic.
-    conditions_for_pauschale = sorted(
-        [cond for cond in all_pauschale_bedingungen_data if cond.get("Pauschale") == pauschale_code],
-        key=lambda x: x.get("BedingungsID", 0)
-    )
+    # Filter conditions for the current pauschale in the order they appear
+    # Keeping the input order avoids altering the intended logical sequence.
+    conditions_for_pauschale = [
+        cond for cond in all_pauschale_bedingungen_data
+        if cond.get("Pauschale") == pauschale_code
+    ]
 
     if not conditions_for_pauschale:
         if debug:

--- a/server.py
+++ b/server.py
@@ -320,16 +320,13 @@ except Exception as e_gen: # Fängt auch andere Fehler während des Imports
     traceback.print_exc()
 
 # --- Globale Datencontainer ---
-leistungskatalog_data: list[dict] = []
 leistungskatalog_dict: dict[str, dict] = {}
 regelwerk_dict: dict[str, list] = {} # Annahme: lade_regelwerk gibt List[RegelDict] pro LKN
 tardoc_tarif_dict: dict[str, dict] = {}
 tardoc_interp_dict: dict[str, dict] = {}
 pauschale_lp_data: list[dict] = []
-pauschalen_data: list[dict] = []
 pauschalen_dict: dict[str, dict] = {}
 pauschale_bedingungen_data: list[dict] = []
-tabellen_data: list[dict] = []
 tabellen_dict_by_table: dict[str, list[dict]] = {}
 # NEU: Indexierte und vorsortierte Pauschalenbedingungen
 pauschale_bedingungen_indexed: Dict[str, List[Dict[str, Any]]] = {}
@@ -379,26 +376,26 @@ def create_app() -> FlaskType:
 
 # --- Daten laden Funktion ---
 def load_data() -> bool:
-    global leistungskatalog_data, leistungskatalog_dict, regelwerk_dict, tardoc_tarif_dict, tardoc_interp_dict
-    global pauschale_lp_data, pauschalen_data, pauschalen_dict, pauschale_bedingungen_data, pauschale_bedingungen_indexed, tabellen_data
+    global leistungskatalog_dict, regelwerk_dict, tardoc_tarif_dict, tardoc_interp_dict
+    global pauschale_lp_data, pauschalen_dict, pauschale_bedingungen_data, pauschale_bedingungen_indexed
     global tabellen_dict_by_table, daten_geladen
 
     all_loaded_successfully = True
     logger.info("--- Lade Daten ---")
     # Reset all data containers
-    leistungskatalog_data.clear(); leistungskatalog_dict.clear(); regelwerk_dict.clear(); tardoc_tarif_dict.clear(); tardoc_interp_dict.clear()
-    pauschale_lp_data.clear(); pauschalen_data.clear(); pauschalen_dict.clear(); pauschale_bedingungen_data.clear(); pauschale_bedingungen_indexed.clear(); tabellen_data.clear()
+    leistungskatalog_dict.clear(); regelwerk_dict.clear(); tardoc_tarif_dict.clear(); tardoc_interp_dict.clear()
+    pauschale_lp_data.clear(); pauschalen_dict.clear(); pauschale_bedingungen_data.clear(); pauschale_bedingungen_indexed.clear()
     tabellen_dict_by_table.clear()
     token_doc_freq.clear()
 
     files_to_load = {
-        "Leistungskatalog": (LEISTUNGSKATALOG_PATH, leistungskatalog_data, 'LKN', leistungskatalog_dict),
+        "Leistungskatalog": (LEISTUNGSKATALOG_PATH, None, 'LKN', leistungskatalog_dict),
         "PauschaleLP": (PAUSCHALE_LP_PATH, pauschale_lp_data, None, None),
-        "Pauschalen": (PAUSCHALEN_PATH, pauschalen_data, 'Pauschale', pauschalen_dict),
+        "Pauschalen": (PAUSCHALEN_PATH, None, 'Pauschale', pauschalen_dict),
         "PauschaleBedingungen": (PAUSCHALE_BED_PATH, pauschale_bedingungen_data, None, None),
-        "TARDOC_TARIF": (TARDOC_TARIF_PATH, [], 'LKN', tardoc_tarif_dict),  # Tarifpositionen
-        "TARDOC_INTERP": (TARDOC_INTERP_PATH, [], 'LKN', tardoc_interp_dict),  # Interpretationen
-        "Tabellen": (TABELLEN_PATH, tabellen_data, None, None)  # Tabellen nur in Liste (vorerst)
+        "TARDOC_TARIF": (TARDOC_TARIF_PATH, None, 'LKN', tardoc_tarif_dict),  # Tarifpositionen
+        "TARDOC_INTERP": (TARDOC_INTERP_PATH, None, 'LKN', tardoc_interp_dict),  # Interpretationen
+        "Tabellen": (TABELLEN_PATH, None, None, None)  # Tabellen nur für Dict
     }
 
     for name, (path, target_list_ref, key_field, target_dict_ref) in files_to_load.items():

--- a/utils.py
+++ b/utils.py
@@ -26,9 +26,9 @@ def get_table_content(table_ref: str, table_type: str, tabellen_dict_by_table: d
 
         if normalized_key in tabellen_dict_by_table:
             # print(f"DEBUG (get_table_content): Schlüssel '{normalized_key}' gefunden.") # Optional
-            for entry in tabellen_dict_by_table[normalized_key]: # Greife direkt auf die Liste zu
+            for entry in tabellen_dict_by_table[normalized_key]:
                 entry_typ = entry.get(TAB_TYP_KEY)
-                if entry_typ and entry_typ.lower() == table_type.lower():
+                if entry_typ is None or entry_typ.lower() == table_type.lower():
                     code = entry.get(TAB_CODE_KEY)
                     text = get_lang_field(entry, TAB_TEXT_KEY, lang)
                     if code:


### PR DESCRIPTION
## Summary
- avoid storing large JSON lists in memory
- respect original order of conditions in `evaluate_pauschale_logic_orchestrator`
- handle missing `Tabelle_Typ` in `get_table_content`
- enforce single gunicorn worker to reduce RAM consumption

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6872b094a6448323a9e6b789e9f7a4ee