### PR TITLE
I've fixed an issue with parsing the `TARDOC_Interpretationen.json` f…

### DIFF
--- a/server.py
+++ b/server.py
@@ -389,6 +389,16 @@ def load_data() -> bool:
                 with open(path, 'r', encoding='utf-8') as f:
                     data_from_file = json.load(f)
 
+                if name == "TARDOC_INTERP" and isinstance(data_from_file, dict):
+                    # Spezifische Behandlung für TARDOC_Interpretationen.json
+                    logger.info("  Spezialbehandlung für TARDOC_INTERP: Extrahiere Listen aus dem Wörterbuch.")
+                    combined_list = []
+                    for key, value in data_from_file.items():
+                        if isinstance(value, list):
+                            combined_list.extend(value)
+                    data_from_file = combined_list
+                    logger.info("  Kombinierte Liste für TARDOC_INTERP enthält %d Einträge.", len(data_from_file))
+
                 if not isinstance(data_from_file, list):
                      logger.warning("  WARNUNG: %s-Daten in '%s' sind keine Liste, überspringe.", name, path)
                      continue


### PR DESCRIPTION
…ile.

The file is a dictionary containing lists of interpretations, but I was expecting a list. This was causing a warning and preventing the interpretations from being loaded.

I've added special handling for this file to extract the lists from the dictionary and combine them into a single list. This resolves the warning and allows the data to be loaded correctly.