### PR TITLE
Add retry logic with backoff for Gemini requests

### DIFF
--- a/data/baseline_results.json
+++ b/data/baseline_results.json
@@ -662,5 +662,42 @@
       "fr": "stimulateur du nerf hypoglosse\nImplantation stimulateur du nerf hypoglosse",
       "it": "stimolatore del nervo ipoglosso\nImpianto stimolatore del nervo ipoglosso"
     }
+  },
+"17": {
+    "baseline": {
+      "de": {
+        "pauschale": null,
+        "einzelleistungen": [
+          {
+            "code": "AK.05.0020",
+            "qty": 1
+          }
+        ]
+      },
+      "fr": {
+        "pauschale": null,
+        "einzelleistungen": [
+          {
+            "code": "AK.05.0020",
+            "qty": 1
+          }
+        ]
+      },
+      "it": {
+        "pauschale": null,
+        "einzelleistungen": [
+          {
+            "code": "AK.05.0020",
+            "qty": 1
+          }
+        ]
+      }
+    },
+    "current": {},
+    "query": {
+      "de": "Diabetes Betreuung MPK 20 Minuten",
+      "fr": "Suivi du diabète CMA 20 minutes",
+      "it": "Cura del diabete CMA 20 minuti"
+    }
   }
 }

--- a/data/beispiele.json
+++ b/data/beispiele.json
@@ -152,5 +152,14 @@
     "extendedValue_FR": "Implantation stimulateur du nerf hypoglosse",
     "value_IT": "stimolatore del nervo ipoglosso",
     "extendedValue_IT": "Impianto stimolatore del nervo ipoglosso"
+  },
+  {
+    "label": "MPK Diabetesberatung, 20 Minuten",
+    "value_DE": "MPK: Diabetes Betreuung 20 Minuten",
+    "extendedValue_DE": "Diabetes Betreuung MPK 20 Minuten",
+    "value_FR": "Suivi du diabète CMA 20 minutes",
+    "extendedValue_FR": "Suivi du diabète CMA 20 minutes",
+    "value_IT": "Cura del diabete CMA 20 minuti",
+    "extendedValue_IT": "Cura del diabete CMA 20 minuti"
   }
 ]

--- a/prompts.py
+++ b/prompts.py
@@ -218,16 +218,20 @@ Risposta JSON:"""
 --- Leistungskatalog Start ---
 {katalog_context}
 --- Leistungskatalog Ende ---
-Rolle: Du bist ein Experte für den Schweizer Arzttarif TARDOC. Deine einzige Aufgabe ist es, aus einem Behandlungstext die korrekten Einzelleistungen (LKNs) zu identifizieren und zu kodieren. Pauschalen werden ignoriert.
+Rolle: Du bist ein Experte für den Schweizer Arzttarif TARDOC & Pauschalen. Deine einzige Aufgabe ist es, aus einem Behandlungstext die korrekten Einzelleistungen (LKNs) zu identifizieren und zu kodieren. Dieser Tarif gilt für die Leistungen der Ärzteschaft und bei wenigen Leistungenh auch für die medizinischen Praxiskoordinatorinnen (MPK)
 
 Anweisungen: Führe die folgenden Schritte exakt aus:
 
 1. Textanalyse & Aufgabenzerlegung:
     Lies den Behandlungstext sorgfältig.
     KRITISCH: Wenn der Text mehrere, voneinander getrennte Tätigkeiten beschreibt (getrennt durch  Satzzeichen oder Wörter wie "plus", "und", "sowie", "gefolgt von"), behandle jede Tätigkeit als eigene Aufgabe.
-    Beispiel: "Hausärztliche Konsultation 15 Min plus 10 Minuten Beratung Kind"
-    Aufgabe 1: "Hausärztliche Konsultation 15 Min"
-    Aufgabe 2: "10 Minuten Beratung Kind"
+    Beispiel A: "Hausärztliche Konsultation 15 Min plus 10 Minuten Beratung Kind"
+    Aufgabe A1: "Hausärztliche Konsultation 15 Min"
+    Aufgabe A2: "10 Minuten Beratung Kind"
+    Aufgabe A3: "Alter <= 12 Jahre"
+    Beipiel B: "Kiefergelenk, Luxation. Geschlossene Reposition mit Anästhesie durch Anästhesistin"
+    Aufgabe B1: "Geschlossene Reposition Kiefergelenk"
+    Aufgabe B2: "Anästhesie durch Anästhesistin"
     Weise Zeitangaben und andere Details immer der korrekten Aufgabe zu.
 2. LKN-Identifikation (pro Aufgabe):
     Medizinische Interpretation: Verstehe die medizinische Absicht des gesamten Behandlungstextes, nicht nur exakte Worte. Nutze dein Wissen über Synonyme, Fachbegriffe und Umschreibungen.

--- a/server.py
+++ b/server.py
@@ -172,6 +172,8 @@ BASELINE_RESULTS_PATH = DATA_DIR / "baseline_results.json"
 BEISPIELE_PATH = DATA_DIR / "beispiele.json"
 
 # Retry configuration for Gemini API calls
+# Bei HTTP 429 (Rate Limit) wird nach dem Exponential-Backoff-Schema erneut
+# versucht. Die Wartezeit berechnet sich als GEMINI_BACKOFF_SECONDS * (2**Versuch).
 GEMINI_MAX_RETRIES = 3
 GEMINI_BACKOFF_SECONDS = 1.0
 

--- a/server.py
+++ b/server.py
@@ -171,6 +171,10 @@ TABELLEN_PATH = DATA_DIR / "PAUSCHALEN_Tabellen.json"
 BASELINE_RESULTS_PATH = DATA_DIR / "baseline_results.json"
 BEISPIELE_PATH = DATA_DIR / "beispiele.json"
 
+# Retry configuration for Gemini API calls
+GEMINI_MAX_RETRIES = 3
+GEMINI_BACKOFF_SECONDS = 1.0
+
 # --- Typ-Aliase für Klarheit ---
 EvaluateStructuredConditionsType = Callable[[str, Dict[Any, Any], List[Dict[Any, Any]], Dict[str, List[Dict[Any, Any]]]], bool]
 CheckPauschaleConditionsType = Callable[
@@ -558,11 +562,35 @@ def call_gemini_stage1(user_input: str, katalog_context: str, lang: str = "de") 
     }
     logger.info("Sende Anfrage Stufe 1 an Gemini Model: %s...", GEMINI_MODEL)
     try:
-        response = requests.post(gemini_url, json=payload, timeout=90)
-        logger.info("Gemini Stufe 1 Antwort Status Code: %s", response.status_code)
-        response.raise_for_status()
+        response = None
+        for attempt in range(GEMINI_MAX_RETRIES):
+            try:
+                response = requests.post(gemini_url, json=payload, timeout=90)
+                logger.info("Gemini Stufe 1 Antwort Status Code: %s", response.status_code)
+                if response.status_code == 429:
+                    raise requests.exceptions.HTTPError(response=response)
+                response.raise_for_status()
+                break
+            except requests.exceptions.HTTPError as http_err:
+                if (
+                    http_err.response is not None
+                    and http_err.response.status_code == 429
+                    and attempt < GEMINI_MAX_RETRIES - 1
+                ):
+                    wait_time = GEMINI_BACKOFF_SECONDS * (2 ** attempt)
+                    logger.warning(
+                        "Gemini Stufe 1 Rate Limit erreicht. Neuer Versuch in %s Sekunden.",
+                        wait_time,
+                    )
+                    time.sleep(wait_time)
+                    continue
+                raise
+        if response is None:
+            raise ConnectionError("Keine Antwort von Gemini Stufe 1 erhalten")
         gemini_data = response.json()
-        logger.info(f"LLM_S1_RAW_GEMINI_DATA: {json.dumps(gemini_data, ensure_ascii=False)}")
+        logger.info(
+            f"LLM_S1_RAW_GEMINI_DATA: {json.dumps(gemini_data, ensure_ascii=False)}"
+        )
 
 
         candidate: Dict[str, Any] | None = None
@@ -847,9 +875,34 @@ def call_gemini_stage2_mapping(tardoc_lkn: str, tardoc_desc: str, candidate_paus
     }
     logger.info("Sende Anfrage Stufe 2 (Mapping) für %s an Gemini Model: %s...", tardoc_lkn, GEMINI_MODEL)
     try:
-        response = requests.post(gemini_url, json=payload, timeout=60)
-        logger.info("Gemini Stufe 2 (Mapping) Antwort Status Code: %s", response.status_code)
-        response.raise_for_status()
+        response = None
+        for attempt in range(GEMINI_MAX_RETRIES):
+            try:
+                response = requests.post(gemini_url, json=payload, timeout=60)
+                logger.info(
+                    "Gemini Stufe 2 (Mapping) Antwort Status Code: %s",
+                    response.status_code,
+                )
+                if response.status_code == 429:
+                    raise requests.exceptions.HTTPError(response=response)
+                response.raise_for_status()
+                break
+            except requests.exceptions.HTTPError as http_err:
+                if (
+                    http_err.response is not None
+                    and http_err.response.status_code == 429
+                    and attempt < GEMINI_MAX_RETRIES - 1
+                ):
+                    wait_time = GEMINI_BACKOFF_SECONDS * (2 ** attempt)
+                    logger.warning(
+                        "Gemini Stufe 2 (Mapping) Rate Limit erreicht. Neuer Versuch in %s Sekunden.",
+                        wait_time,
+                    )
+                    time.sleep(wait_time)
+                    continue
+                raise
+        if response is None:
+            return None
         gemini_data = response.json()
 
         raw_text_response_part = ""
@@ -939,9 +992,34 @@ def call_gemini_stage2_ranking(user_input: str, potential_pauschalen_text: str, 
     payload = {"contents": [{"parts": [{"text": prompt}]}], "generationConfig": {"temperature": 0.1, "maxOutputTokens": 500}}
     logger.info("Sende Anfrage Stufe 2 (Ranking) an Gemini Model: %s...", GEMINI_MODEL)
     try:
-        response = requests.post(gemini_url, json=payload, timeout=45)
-        logger.info("Gemini Stufe 2 (Ranking) Antwort Status Code: %s", response.status_code)
-        response.raise_for_status()
+        response = None
+        for attempt in range(GEMINI_MAX_RETRIES):
+            try:
+                response = requests.post(gemini_url, json=payload, timeout=45)
+                logger.info(
+                    "Gemini Stufe 2 (Ranking) Antwort Status Code: %s",
+                    response.status_code,
+                )
+                if response.status_code == 429:
+                    raise requests.exceptions.HTTPError(response=response)
+                response.raise_for_status()
+                break
+            except requests.exceptions.HTTPError as http_err:
+                if (
+                    http_err.response is not None
+                    and http_err.response.status_code == 429
+                    and attempt < GEMINI_MAX_RETRIES - 1
+                ):
+                    wait_time = GEMINI_BACKOFF_SECONDS * (2 ** attempt)
+                    logger.warning(
+                        "Gemini Stufe 2 (Ranking) Rate Limit erreicht. Neuer Versuch in %s Sekunden.",
+                        wait_time,
+                    )
+                    time.sleep(wait_time)
+                    continue
+                raise
+        if response is None:
+            return []
         gemini_data = response.json()
 
         ranked_text = ""


### PR DESCRIPTION
## Summary
- define retry constants for Gemini API
- retry Gemini API calls in all call_gemini functions when receiving HTTP 429

## Testing
- `pytest -q` *(fails: C01.05B logic tests)*

------
https://chatgpt.com/codex/tasks/task_e_6875597b96d8832393ded4916b4d3072