### PR TITLE
Display ranked LKN candidates when ambiguous

### DIFF
--- a/calculator.js
+++ b/calculator.js
@@ -44,6 +44,7 @@ const DYN_TEXT = {
         llmExtr: 'Vom KI extrahierte Details:',
         llmNoneExtr: 'Keine zusätzlichen Details von der KI extrahiert.',
         llmReason: 'Begründung KI (Stufe 1):',
+        llmRankedLkns: 'Weitere mögliche LKN (Ranking):',
         llmDetails2: 'Details KI-Analyse Stufe 2 (TARDOC-zu-Pauschalen-LKN Mapping)',
         mappingIntro: 'Folgende TARDOC LKNs wurden versucht, auf äquivalente Pauschalen-Bedingungs-LKNs zu mappen:',
         ruleDetails: 'Details Regelprüfung',
@@ -95,6 +96,7 @@ const DYN_TEXT = {
         llmExtr: 'Détails extraits par IA :',
         llmNoneExtr: 'Aucun détail supplémentaire extrait par IA.',
         llmReason: 'Justification IA (Niveau 1) :',
+        llmRankedLkns: 'Autres NPL possibles (classement) :',
         llmDetails2: 'Détails analyse IA niveau 2 (mappage TARDOC vers forfaits)',
         mappingIntro: 'Les NPL TARDOC suivants ont été mis en correspondance avec des NPL de conditions de forfait :',
         ruleDetails: 'Détails contrôle des règles',
@@ -146,6 +148,7 @@ const DYN_TEXT = {
         llmExtr: 'Dettagli estratti dal IA:',
         llmNoneExtr: 'Nessun dettaglio aggiuntivo estratto dal IA.',
         llmReason: 'Motivazione IA (Livello 1):',
+        llmRankedLkns: 'Altri NPL possibili (classifica):',
         llmDetails2: 'Dettagli analisi IA livello 2 (mappatura TARDOC a forfait)',
         mappingIntro: 'I seguenti NPL TARDOC sono stati mappati su NPL di condizioni forfait:',
         ruleDetails: 'Dettagli verifica regole',
@@ -1157,6 +1160,16 @@ function generateLlmStage1Details(llmResult) {
         detailsHtml += `</ul>`;
     } else {
         detailsHtml += `<p><i>${tDyn('llmNoneIdent')}</i></p>`;
+    }
+
+    const rankedList = llmResult.ranking_candidates || [];
+    if (Array.isArray(rankedList) && rankedList.length > 1) {
+        detailsHtml += `<p><b>${tDyn('llmRankedLkns')}</b></p><ol>`;
+        rankedList.forEach(code => {
+            const desc = beschreibungZuLKN(code);
+            detailsHtml += `<li><a href="https://tarifbrowser.oaat-otma.ch/startPortal?search=${encodeURIComponent(code)}" target="_blank">${escapeHtml(code)}</a> ${escapeHtml(desc)}</li>`;
+        });
+        detailsHtml += `</ol>`;
     }
 
     let extractedDetails = [];

--- a/calculator.js
+++ b/calculator.js
@@ -1167,7 +1167,7 @@ function generateLlmStage1Details(llmResult) {
         detailsHtml += `<p><b>${tDyn('llmRankedLkns')}</b></p><ol>`;
         rankedList.forEach(code => {
             const desc = beschreibungZuLKN(code);
-            detailsHtml += `<li><a href="https://tarifbrowser.oaat-otma.ch/startPortal?search=${encodeURIComponent(code)}" target="_blank">${escapeHtml(code)}</a> ${escapeHtml(desc)}</li>`;
+            detailsHtml += `<li>${createInfoLink(code,'lkn')} ${escapeHtml(desc)}</li>`;
         });
         detailsHtml += `</ol>`;
     }

--- a/selector.py
+++ b/selector.py
@@ -30,8 +30,13 @@ def rank_leistungskatalog_entries(
     leistungskatalog_dict: Dict[str, Dict[str, Any]],
     token_doc_freq: Dict[str, int],
     limit: int = 200,
-) -> List[str]:
-    """Return LKN codes ranked by weighted token occurrences."""
+    return_scores: bool = False,
+) -> List[str] | List[Tuple[float, str]]:
+    """Return LKN codes ranked by weighted token occurrences.
+
+    If ``return_scores`` is ``True`` the result is a list of ``(score, code)``
+    tuples, otherwise just the codes are returned.
+    """
     scored: List[Tuple[float, str]] = []
     for lkn_code, details in leistungskatalog_dict.items():
         texts = []
@@ -57,4 +62,6 @@ def rank_leistungskatalog_entries(
         if score > 0:
             scored.append((score, lkn_code))
     scored.sort(key=lambda x: x[0], reverse=True)
+    if return_scores:
+        return scored[:limit]
     return [code for _, code in scored[:limit]]

--- a/server.py
+++ b/server.py
@@ -111,7 +111,7 @@ except ModuleNotFoundError:
     def load_dotenv(*a, **k) -> bool:
         return False
 import regelpruefer # Dein Modul
-from typing import Dict, List, Any, Set, Tuple, Callable # Tuple und Callable hinzugefügt
+from typing import Dict, List, Any, Set, Tuple, Callable, cast  # Tuple und Callable hinzugefügt
 from utils import (
     get_table_content,
     translate_rule_error_message,
@@ -1294,12 +1294,15 @@ def analyze_billing():
             logger.info(f"DEBUG: Beispiel token_doc_freq Key: {next(iter(token_doc_freq.keys()))}")
         # --- DEBUGGING END ---
 
-        ranked_results = rank_leistungskatalog_entries(
-            tokens,
-            leistungskatalog_dict,
-            token_doc_freq,
-            500,
-            return_scores=True,
+        ranked_results = cast(
+            List[Tuple[float, str]],
+            rank_leistungskatalog_entries(
+                tokens,
+                leistungskatalog_dict,
+                token_doc_freq,
+                500,
+                return_scores=True,
+            ),
         )
         ranked_codes = [code for _, code in ranked_results]
         top_ranking_results = ranked_results[:5]

--- a/server.py
+++ b/server.py
@@ -1273,6 +1273,7 @@ def analyze_billing():
     )
 
     llm_stage1_result: Dict[str, Any] = {"identified_leistungen": [], "extracted_info": {}, "begruendung_llm": ""}
+    top_ranking_results: List[Tuple[float, str]] = []
     try:
         katalog_context_parts = []
         preprocessed_input = expand_compound_words(user_input)
@@ -1293,7 +1294,15 @@ def analyze_billing():
             logger.info(f"DEBUG: Beispiel token_doc_freq Key: {next(iter(token_doc_freq.keys()))}")
         # --- DEBUGGING END ---
 
-        ranked_codes = rank_leistungskatalog_entries(tokens, leistungskatalog_dict, token_doc_freq, 500)
+        ranked_results = rank_leistungskatalog_entries(
+            tokens,
+            leistungskatalog_dict,
+            token_doc_freq,
+            500,
+            return_scores=True,
+        )
+        ranked_codes = [code for _, code in ranked_results]
+        top_ranking_results = ranked_results[:5]
         if direct_codes:
             ranked_codes = list(dict.fromkeys(direct_codes + ranked_codes))
         # --- DEBUGGING START ---
@@ -1374,6 +1383,20 @@ def analyze_billing():
             )
     llm_stage1_result["identified_leistungen"] = final_validated_llm_leistungen
     logger.info("%s LKNs nach LLM Stufe 1 und lokaler Katalogvalidierung.", len(final_validated_llm_leistungen))
+
+    candidate_codes: List[str] = []
+    if top_ranking_results:
+        if len(top_ranking_results) > 1:
+            ratio = (
+                top_ranking_results[0][0] / top_ranking_results[1][0]
+                if top_ranking_results[1][0] != 0
+                else float("inf")
+            )
+        else:
+            ratio = float("inf")
+        if not final_validated_llm_leistungen or ratio <= 1.5:
+            candidate_codes = [code for _, code in top_ranking_results]
+    llm_stage1_result["ranking_candidates"] = candidate_codes
 
     extracted_info_llm = llm_stage1_result.get("extracted_info", {})
     alter_context_val = alter_user if alter_user is not None else extracted_info_llm.get("alter")


### PR DESCRIPTION
## Summary
- extend `rank_leistungskatalog_entries` to optionally return scores
- compute ranked candidates in `analyze_billing` and expose them when no clear winner exists
- show ranked LKN links in UI (translated)

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6877e812fdb483239272c4d89e3d939d