### PR TITLE
Add user feedback via GitHub issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.tar.gz 
 data/beispiele.json filter=lfs diff=lfs merge=lfs -text
 # Andere temporäre oder lokale Dateien/Ordner
+feedback_local.json

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -68,8 +68,11 @@ Erstelle eine Datei namens `.env` im Projektstammverzeichnis (diese Datei wird d
 Inhalt der `.env`-Datei:
 ```env
 GEMINI_API_KEY="DEIN_GEMINI_API_KEY"
+GITHUB_TOKEN="DEIN_GITHUB_TOKEN"
+GITHUB_REPO="USER/REPO"
 ```
 Ersetze `DEIN_GEMINI_API_KEY` durch deinen Schlüssel.
+Wenn du Feedback automatisch als GitHub-Issue erfassen möchtest, musst du zusätzlich `GITHUB_TOKEN` und `GITHUB_REPO` setzen. `GITHUB_REPO` sollte im Format `benutzername/repository` angegeben werden. **Der bereitgestellte Token läuft am 19.07.2026 ab.**
 
 **3.6. Anwendung lokal starten**
 ```bash

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -69,10 +69,12 @@ Inhalt der `.env`-Datei:
 ```env
 GEMINI_API_KEY="DEIN_GEMINI_API_KEY"
 GITHUB_TOKEN="DEIN_GITHUB_TOKEN"
-GITHUB_REPO="USER/REPO"
+GITHUB_REPO="BeatArnet/Arzttarif-Assistent"
 ```
 Ersetze `DEIN_GEMINI_API_KEY` durch deinen Schlüssel.
-Wenn du Feedback automatisch als GitHub-Issue erfassen möchtest, musst du zusätzlich `GITHUB_TOKEN` und `GITHUB_REPO` setzen. `GITHUB_REPO` sollte im Format `benutzername/repository` angegeben werden. **Der bereitgestellte Token läuft am 19.07.2026 ab.**
+Wenn du Feedback automatisch als GitHub-Issue erfassen möchtest, musst du zusätzlich `GITHUB_TOKEN` und `GITHUB_REPO` setzen. `GITHUB_REPO` sollte im Format `BeatArnet/Arzttarif-Assistent` angegeben werden. **Der bereitgestellte Token läuft am 19.07.2026 ab.**
+A personal access token (classic) "Für Feedback durch alle User im Arzttarif Assistenten" with repo scope was recently added to your account. Visit https://github.com/settings/tokens for more information.
+To see this and other security events for your account, visit https://github.com/settings/security-log
 
 **3.6. Anwendung lokal starten**
 ```bash

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Dies ist ein Prototyp einer Webanwendung zur Unterstützung bei der Abrechnung m
 
 ### V2.2 (Aktuell)
 - Dokumentation (README.md, INSTALLATION.md) aktualisiert mit den neuesten Hinweisen und Versionsdetails.
+- Neue Feedback-Funktion: Über ein Formular kann Feedback an ein GitHub-Repository gesendet oder lokal gespeichert werden, wenn keine GitHub-Konfiguration vorliegt.
 
 ### V2.0
 - **Qualitätstests und Baseline-Vergleiche:** Einführung einer neuen Testseite (`quality.html`, `quality.js`) und eines Skripts (`run_quality_tests.py`) zum automatisierten Vergleich von Beispielen mit Referenzwerten (`baseline_results.json`). Ein neuer Backend-Endpunkt `/api/quality` wurde dafür in `server.py` hinzugefügt.
@@ -118,6 +119,10 @@ Die Datei `data/beispiele.json` enthält Testfälle. Mit `run_quality_tests.py` 
 ```bash
 python run_quality_tests.py
 ```
+
+## Feedback
+
+Über den Button "Feedback geben" können Nutzende Kommentare abgeben. Wenn die Umgebungsvariablen `GITHUB_TOKEN` und `GITHUB_REPO` gesetzt sind, wird daraus automatisch ein GitHub-Issue erstellt. Andernfalls speichert die Anwendung das Feedback lokal in `feedback_local.json`.
 
 ## Unittests mit `pytest`
 

--- a/calculator.js
+++ b/calculator.js
@@ -18,6 +18,8 @@ let dignitaetenMap = {}; // For mapping dignity codes to text
 // Zusätzliche Pauschalen-Infos
 let selectedPauschaleDetails = null;
 let evaluatedPauschalenList = [];
+let lastBackendResponse = null; // Speichert die letzte Serverantwort für Feedback
+let lastUserInput = "";
 
 // Dynamische Übersetzungen
 const DYN_TEXT = {
@@ -1020,6 +1022,8 @@ async function getBillingAnalysis() {
         // console.log("[getBillingAnalysis] Raw Response vom Backend erhalten:", rawResponseText.substring(0, 500) + "..."); // Gekürzt loggen
         if (!res.ok) { throw new Error(`Server antwortete mit ${res.status}`); }
         backendResponse = JSON.parse(rawResponseText);
+        lastBackendResponse = backendResponse; // Für spätere Feedback-Übermittlung
+        lastUserInput = userInput;
         console.log("[getBillingAnalysis] Backend-Antwort geparst.");
         console.log("[getBillingAnalysis] Empfangene Backend-Daten (Ausschnitt):", {
             begruendung_llm_stufe1: backendResponse?.llm_ergebnis_stufe1?.begruendung_llm}); // Logge spezifisch die Begründung       

--- a/index.html
+++ b/index.html
@@ -408,6 +408,8 @@
         #qualityLink { color: var(--primary); text-decoration:none; }
         #qualityLink:hover { text-decoration: underline; }
         @keyframes spin { to { transform: rotate(360deg); } }
+        #feedbackContainer label { margin-top: 10px; }
+        #feedbackStatus { font-weight: bold; margin-top: 10px; }
 </style>
 </head>
 <body>
@@ -500,7 +502,7 @@
         <!-- Content will be inserted by JavaScript -->
     </div>
 
-    <button id="feedbackButton" onclick="toggleFeedback()">Feedback geben</button>
+    <button id="feedbackButton" type="button">Feedback geben</button>
     <div id="feedbackContainer" style="display:none; margin-top:15px;">
         <label for="feedbackCategory" id="fbCategoryLabel">Kategorie:</label>
         <select id="feedbackCategory">
@@ -513,7 +515,7 @@
         <input type="text" id="feedbackCode">
         <label for="feedbackText" id="fbMessageLabel">Nachricht:</label>
         <textarea id="feedbackText" rows="3"></textarea>
-        <button onclick="sendFeedback()" id="fbSubmitButton">Absenden</button>
+        <button id="fbSubmitButton" type="button">Absenden</button>
         <div id="feedbackStatus" style="margin-top:10px;"></div>
     </div>
 
@@ -736,6 +738,8 @@
             if(selB) selB.selectedIndex=0;
         }
         document.getElementById('languageSelect').addEventListener('change',e=>applyLanguage(e.target.value));
+        document.getElementById('feedbackButton').addEventListener('click',toggleFeedback);
+        document.getElementById('fbSubmitButton').addEventListener('click',sendFeedback);
         document.addEventListener('DOMContentLoaded',initLanguage);
 
         function toggleFeedback(){

--- a/index.html
+++ b/index.html
@@ -766,14 +766,17 @@
                     headers: {'Content-Type':'application/json'},
                     body: JSON.stringify(payload)
                 });
+                let data = {};
+                try { data = await resp.json(); } catch(_) {}
                 if(resp.ok){
                     if(status) status.textContent = translations[currentLang].fbThanks;
                     document.getElementById('feedbackText').value = '';
                 } else {
-                    if(status) status.textContent = 'Fehler';
+                    const msg = data.error || translations[currentLang].fail;
+                    if(status) status.textContent = msg;
                 }
             }catch(e){
-                if(status) status.textContent = 'Fehler';
+                if(status) status.textContent = translations[currentLang].fail;
             }
         }
     </script>

--- a/index.html
+++ b/index.html
@@ -749,7 +749,12 @@
             const payload = {
                 category: document.getElementById('feedbackCategory').value,
                 code: document.getElementById('feedbackCode').value,
-                message: document.getElementById('feedbackText').value
+                message: document.getElementById('feedbackText').value,
+                user_input: (typeof lastUserInput !== 'undefined' ? lastUserInput : document.getElementById('userInput').value),
+                pauschale: (typeof selectedPauschaleDetails === 'object' && selectedPauschaleDetails ? selectedPauschaleDetails.Pauschale : null),
+                einzelleistungen: Array.isArray(lastBackendResponse?.abrechnung?.leistungen) ? lastBackendResponse.abrechnung.leistungen : [],
+                begruendung_llm1: lastBackendResponse?.llm_ergebnis_stufe1?.begruendung_llm || '',
+                begruendung_llm2: JSON.stringify(lastBackendResponse?.llm_ergebnis_stufe2 || {})
             };
             try{
                 const resp = await fetch('/api/submit-feedback', {

--- a/index.html
+++ b/index.html
@@ -500,6 +500,23 @@
         <!-- Content will be inserted by JavaScript -->
     </div>
 
+    <button id="feedbackButton" onclick="toggleFeedback()">Feedback geben</button>
+    <div id="feedbackContainer" style="display:none; margin-top:15px;">
+        <label for="feedbackCategory" id="fbCategoryLabel">Kategorie:</label>
+        <select id="feedbackCategory">
+            <option value="Allgemein">Allgemein</option>
+            <option value="Leistungsbeschreibung">Leistungsbeschreibung</option>
+            <option value="Pauschale">Pauschale</option>
+            <option value="Einzelleistung">Einzelleistung</option>
+        </select>
+        <label for="feedbackCode" id="fbCodeLabel">Code (optional):</label>
+        <input type="text" id="feedbackCode">
+        <label for="feedbackText" id="fbMessageLabel">Nachricht:</label>
+        <textarea id="feedbackText" rows="3"></textarea>
+        <button onclick="sendFeedback()" id="fbSubmitButton">Absenden</button>
+        <div id="feedbackStatus" style="margin-top:10px;"></div>
+    </div>
+
     <script src="calculator.js"></script>
     <script>
         const translations = {
@@ -535,7 +552,13 @@
                 testExample: 'Beispiel testen',
                 testAll: 'Alle Beispiele testen',
                 pass: 'OK',
-                fail: 'Fehler'
+                fail: 'Fehler',
+                feedbackButton: 'Feedback geben',
+                fbCategory: 'Kategorie:',
+                fbCode: 'Code (optional):',
+                fbMessage: 'Nachricht:',
+                fbSubmit: 'Absenden',
+                fbThanks: 'Vielen Dank für das Feedback!'
             },
             fr: {
                 langLabel: 'Langue :',
@@ -570,7 +593,13 @@
                 testExample: 'Tester exemple',
                 testAll: 'Tester tous les exemples',
                 pass: 'OK',
-                fail: 'Erreur'
+                fail: 'Erreur',
+                feedbackButton: 'Envoyer un feedback',
+                fbCategory: 'Catégorie:',
+                fbCode: 'Code (optionnel):',
+                fbMessage: 'Message:',
+                fbSubmit: 'Envoyer',
+                fbThanks: 'Merci pour votre feedback!'
             },
             it: {
                 langLabel: 'Lingua:',
@@ -604,7 +633,13 @@
                 testExample: 'Prova esempio',
                 testAll: 'Testa tutti gli esempi',
                 pass: 'OK',
-                fail: 'Errore'
+                fail: 'Errore',
+                feedbackButton: 'Invia feedback',
+                fbCategory: 'Categoria:',
+                fbCode: 'Codice (opzionale):',
+                fbMessage: 'Messaggio:',
+                fbSubmit: 'Invia',
+                fbThanks: 'Grazie per il feedback!'
             }
         };
         let examplesData = [];
@@ -657,6 +692,16 @@
             document.getElementById('spinner').textContent = t.loading;
             const qLink = document.getElementById('qualityLink');
             if(qLink) qLink.textContent = t.qualityLink;
+            const fbBtn = document.getElementById('feedbackButton');
+            if(fbBtn) fbBtn.textContent = t.feedbackButton;
+            const fbCat = document.getElementById('fbCategoryLabel');
+            if(fbCat) fbCat.textContent = t.fbCategory;
+            const fbCode = document.getElementById('fbCodeLabel');
+            if(fbCode) fbCode.textContent = t.fbCode;
+            const fbMsg = document.getElementById('fbMessageLabel');
+            if(fbMsg) fbMsg.textContent = t.fbMessage;
+            const fbSub = document.getElementById('fbSubmitButton');
+            if(fbSub) fbSub.textContent = t.fbSubmit;
             const out = document.getElementById('output');
             if(out){
                 const prev = translations[prevLang] || translations['de'];
@@ -692,6 +737,36 @@
         }
         document.getElementById('languageSelect').addEventListener('change',e=>applyLanguage(e.target.value));
         document.addEventListener('DOMContentLoaded',initLanguage);
+
+        function toggleFeedback(){
+            const c = document.getElementById('feedbackContainer');
+            if(c) c.style.display = c.style.display === 'none' ? 'block' : 'none';
+        }
+
+        async function sendFeedback(){
+            const status = document.getElementById('feedbackStatus');
+            if(status) status.textContent = '';
+            const payload = {
+                category: document.getElementById('feedbackCategory').value,
+                code: document.getElementById('feedbackCode').value,
+                message: document.getElementById('feedbackText').value
+            };
+            try{
+                const resp = await fetch('/api/submit-feedback', {
+                    method: 'POST',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify(payload)
+                });
+                if(resp.ok){
+                    if(status) status.textContent = translations[currentLang].fbThanks;
+                    document.getElementById('feedbackText').value = '';
+                } else {
+                    if(status) status.textContent = 'Fehler';
+                }
+            }catch(e){
+                if(status) status.textContent = 'Fehler';
+            }
+        }
     </script>
 </body>
 </html>

--- a/server.py
+++ b/server.py
@@ -5,7 +5,7 @@ import json
 import time # für Zeitmessung
 import traceback # für detaillierte Fehlermeldungen
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -1984,7 +1984,7 @@ def submit_feedback() -> Any:
     if not token or not repo:
         # Fallback: store feedback locally if GitHub is not configured
         entry = {
-            "timestamp": datetime.utcnow().isoformat() + "Z",
+            "timestamp": datetime.now(timezone.utc).isoformat(),
             "category": category,
             "code": code,
             "message": message,

--- a/server.py
+++ b/server.py
@@ -1977,12 +1977,32 @@ def submit_feedback() -> Any:
     category = data.get("category", "Allgemein")
     code = (data.get("code") or "").strip()
     message = data.get("message", "")
+    user_input = data.get("user_input", "")
+    pauschale = data.get("pauschale")
+    einzelleistungen = data.get("einzelleistungen", [])
+    begruendung1 = data.get("begruendung_llm1", "")
+    begruendung2 = data.get("begruendung_llm2", "")
 
     title_parts = [category]
     if code:
         title_parts.append(code)
     title = " - ".join(title_parts)
-    body = f"**Kategorie:** {category}\n" + (f"**Code:** {code}\n" if code else "") + f"\n{message}"
+    body_lines = [f"**Kategorie:** {category}"]
+    if code:
+        body_lines.append(f"**Code:** {code}")
+    if user_input:
+        body_lines.append(f"**User Input:** {user_input}")
+    if pauschale:
+        body_lines.append(f"**Pauschale:** {pauschale}")
+    if einzelleistungen:
+        body_lines.append("**Einzelleistungen:** " + ", ".join(map(str, einzelleistungen)))
+    if begruendung1:
+        body_lines.append("**Begründung LLM Stufe 1:**\n" + begruendung1)
+    if begruendung2:
+        body_lines.append("**Begründung LLM Stufe 2:**\n" + begruendung2)
+    body_lines.append("")
+    body_lines.append(message)
+    body = "\n".join(body_lines)
 
     issue_url = f"https://api.github.com/repos/{repo}/issues"
     headers = {

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -67,3 +67,18 @@ def test_analyze_billing_with_unknown_lkn():
         with server.app.test_client() as client:
             response = client.post('/api/analyze-billing', json={'inputText': 'GG.99.9999 5 Minuten'})
             assert response.status_code == 200
+
+def test_submit_feedback_local(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GITHUB_REPO", raising=False)
+    with server.app.test_client() as client:
+        resp = client.post('/api/submit-feedback', json={
+            'category': 'Allgemein',
+            'message': 'Unit test feedback'
+        })
+        assert resp.status_code == 200
+        data = resp.get_json()
+        assert data.get('status') == 'saved'
+    stored = json.loads(Path('feedback_local.json').read_text(encoding='utf-8'))
+    assert stored[-1]['message'] == 'Unit test feedback'


### PR DESCRIPTION
## Summary
- add API routes to send feedback as GitHub issues and fetch approved items
- show a feedback form in the UI
- include translations for the feedback form

## Testing
- `pytest -q`
- `python run_quality_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*
- `pip install -r requirements.txt` *(fails: connection error)*

------
https://chatgpt.com/codex/tasks/task_e_687a9a9e03bc83239fc57e87d2b039a4