### PR TITLE
Handle feedback locally when GitHub unavailable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ __pycache__/
 *.tar.gz 
 data/beispiele.json filter=lfs diff=lfs merge=lfs -text
 # Andere temporäre oder lokale Dateien/Ordner
+feedback_local.json

--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -68,8 +68,11 @@ Erstelle eine Datei namens `.env` im Projektstammverzeichnis (diese Datei wird d
 Inhalt der `.env`-Datei:
 ```env
 GEMINI_API_KEY="DEIN_GEMINI_API_KEY"
+GITHUB_TOKEN="DEIN_GITHUB_TOKEN"
+GITHUB_REPO="USER/REPO"
 ```
 Ersetze `DEIN_GEMINI_API_KEY` durch deinen Schlüssel.
+Wenn du Feedback automatisch als GitHub-Issue erfassen möchtest, musst du zusätzlich `GITHUB_TOKEN` und `GITHUB_REPO` setzen. `GITHUB_REPO` sollte im Format `benutzername/repository` angegeben werden. **Der bereitgestellte Token läuft am 19.07.2026 ab.**
 
 **3.6. Anwendung lokal starten**
 ```bash

--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ Dies ist ein Prototyp einer Webanwendung zur Unterstützung bei der Abrechnung m
 
 ## Versionsübersicht
 
-### V2.2 (Aktuell)
+### V2.3 (Aktuell)
+- Überarbeitetes Feedback-Modul mit modalem Formular und Kontextinformationen.
+
+### V2.2
 - Dokumentation (README.md, INSTALLATION.md) aktualisiert mit den neuesten Hinweisen und Versionsdetails.
+- Neue Feedback-Funktion: Über ein Formular kann Feedback an ein GitHub-Repository gesendet oder lokal gespeichert werden, wenn keine GitHub-Konfiguration vorliegt.
 
 ### V2.0
 - **Qualitätstests und Baseline-Vergleiche:** Einführung einer neuen Testseite (`quality.html`, `quality.js`) und eines Skripts (`run_quality_tests.py`) zum automatisierten Vergleich von Beispielen mit Referenzwerten (`baseline_results.json`). Ein neuer Backend-Endpunkt `/api/quality` wurde dafür in `server.py` hinzugefügt.
@@ -118,6 +122,10 @@ Die Datei `data/beispiele.json` enthält Testfälle. Mit `run_quality_tests.py` 
 ```bash
 python run_quality_tests.py
 ```
+
+## Feedback
+
+Über den Button "Feedback geben" öffnet sich ein modales Formular. Es sammelt automatisch Kontextinformationen (URL, Browser, Bildschirmauflösung sowie die aktuellen Eingaben) und sendet sie zusammen mit der Nachricht an das Backend. Sind `GITHUB_TOKEN` und `GITHUB_REPO` gesetzt, wird daraus ein GitHub-Issue erstellt, ansonsten landet das Feedback in `feedback_local.json`.
 
 ## Unittests mit `pytest`
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ python run_quality_tests.py
 
 ## Feedback
 
-Über den Button "Feedback geben" öffnet sich ein modales Formular. Es sammelt automatisch Kontextinformationen (URL, Browser, Bildschirmauflösung sowie die aktuellen Eingaben) und sendet sie zusammen mit der Nachricht an das Backend. Sind `GITHUB_TOKEN` und `GITHUB_REPO` gesetzt, wird daraus ein GitHub-Issue erstellt, ansonsten landet das Feedback in `feedback_local.json`.
+Über den Button "Feedback geben" oben neben der Sprachauswahl öffnet sich ein modales Formular. Es sammelt automatisch Kontextinformationen (URL, Browser, Bildschirmauflösung sowie eine Momentaufnahme der aktuellen Formulareingaben und Analyseergebnisse) und sendet sie zusammen mit der Nachricht an das Backend. Sind `GITHUB_TOKEN` und `GITHUB_REPO` gesetzt, wird daraus ein GitHub-Issue erstellt, ansonsten landet das Feedback in `feedback_local.json`.
 
 ## Unittests mit `pytest`
 

--- a/calculator.js
+++ b/calculator.js
@@ -18,6 +18,8 @@ let dignitaetenMap = {}; // For mapping dignity codes to text
 // Zusätzliche Pauschalen-Infos
 let selectedPauschaleDetails = null;
 let evaluatedPauschalenList = [];
+let lastBackendResponse = null; // Speichert die letzte Serverantwort für Feedback
+let lastUserInput = "";
 
 // Dynamische Übersetzungen
 const DYN_TEXT = {
@@ -1020,6 +1022,8 @@ async function getBillingAnalysis() {
         // console.log("[getBillingAnalysis] Raw Response vom Backend erhalten:", rawResponseText.substring(0, 500) + "..."); // Gekürzt loggen
         if (!res.ok) { throw new Error(`Server antwortete mit ${res.status}`); }
         backendResponse = JSON.parse(rawResponseText);
+        lastBackendResponse = backendResponse; // Für spätere Feedback-Übermittlung
+        lastUserInput = userInput;
         console.log("[getBillingAnalysis] Backend-Antwort geparst.");
         console.log("[getBillingAnalysis] Empfangene Backend-Daten (Ausschnitt):", {
             begruendung_llm_stufe1: backendResponse?.llm_ergebnis_stufe1?.begruendung_llm}); // Logge spezifisch die Begründung       

--- a/index.html
+++ b/index.html
@@ -474,7 +474,7 @@
         </div>
         <a id="qualityLink" href="quality.html">Qualitätskontrolle</a>
         <div class="version-info">
-            V2.1, Arnet Konsilium,
+            V2.3, Arnet Konsilium,
             <a href="https://www.arkons.ch/" target="_blank">https://www.arkons.ch/</a>,
             2025
         </div>

--- a/index.html
+++ b/index.html
@@ -408,6 +408,13 @@
         #qualityLink { color: var(--primary); text-decoration:none; }
         #qualityLink:hover { text-decoration: underline; }
         @keyframes spin { to { transform: rotate(360deg); } }
+        #feedbackContainer label { margin-top: 10px; }
+        #feedbackStatus { font-weight: bold; margin-top: 10px; }
+
+        /* Feedback Modal */
+        #feedbackModal { width: 400px; height: auto; max-height: 80vh; }
+        #feedbackModalBody { display: flex; flex-direction: column; gap: 10px; }
+        #feedbackModal textarea { width: 100%; resize: vertical; }
 </style>
 </head>
 <body>
@@ -500,6 +507,36 @@
         <!-- Content will be inserted by JavaScript -->
     </div>
 
+    <button id="feedbackButton" type="button">Feedback geben</button>
+    <div id="feedbackModalOverlay" class="info-modal-overlay" style="display:none;">
+        <div id="feedbackModal" class="info-modal" style="width:400px;height:auto;top:20vh;left:calc(50% - 200px);">
+            <button id="feedbackModalClose" class="modal-close">&times;</button>
+            <h2 id="feedbackModalTitle">Provide Feedback</h2>
+            <div id="feedbackModalBody">
+                <label for="feedbackCategory" id="fbCategoryLabel">Kategorie:</label>
+                <select id="feedbackCategory">
+                    <option value="Allgemein">Allgemein</option>
+                    <option value="Leistungsbeschreibung">Leistungsbeschreibung</option>
+                    <option value="Pauschale">Pauschale</option>
+                    <option value="Einzelleistung">Einzelleistung</option>
+                </select>
+                <label for="feedbackCode" id="fbCodeLabel">Code (optional):</label>
+                <input type="text" id="feedbackCode">
+                <label for="feedbackText" id="fbMessageLabel">Nachricht:</label>
+                <textarea id="feedbackText" rows="3"></textarea>
+                <details id="fbContextDetails">
+                    <summary id="fbContextLabel">Kontext</summary>
+                    <pre id="fbContextPre" style="white-space:pre-wrap;"></pre>
+                </details>
+                <div style="display:flex; gap:10px; margin-top:10px;">
+                    <button id="fbSubmitButton" type="button">Absenden</button>
+                    <button id="fbCancelButton" type="button">Abbrechen</button>
+                </div>
+                <div id="feedbackStatus" style="margin-top:10px;"></div>
+            </div>
+        </div>
+    </div>
+
     <script src="calculator.js"></script>
     <script>
         const translations = {
@@ -535,7 +572,16 @@
                 testExample: 'Beispiel testen',
                 testAll: 'Alle Beispiele testen',
                 pass: 'OK',
-                fail: 'Fehler'
+                fail: 'Fehler',
+                feedbackButton: 'Feedback geben',
+                fbCategory: 'Kategorie:',
+                fbCode: 'Code (optional):',
+                fbMessage: 'Nachricht:',
+                fbSubmit: 'Absenden',
+                fbCancel: 'Abbrechen',
+                feedbackTitle: 'Feedback geben',
+                fbContext: 'Kontext',
+                fbThanks: 'Vielen Dank für das Feedback!'
             },
             fr: {
                 langLabel: 'Langue :',
@@ -570,7 +616,16 @@
                 testExample: 'Tester exemple',
                 testAll: 'Tester tous les exemples',
                 pass: 'OK',
-                fail: 'Erreur'
+                fail: 'Erreur',
+                feedbackButton: 'Envoyer un feedback',
+                fbCategory: 'Catégorie:',
+                fbCode: 'Code (optionnel):',
+                fbMessage: 'Message:',
+                fbSubmit: 'Envoyer',
+                fbCancel: 'Annuler',
+                feedbackTitle: 'Envoyer un feedback',
+                fbContext: 'Contexte',
+                fbThanks: 'Merci pour votre feedback!'
             },
             it: {
                 langLabel: 'Lingua:',
@@ -604,7 +659,16 @@
                 testExample: 'Prova esempio',
                 testAll: 'Testa tutti gli esempi',
                 pass: 'OK',
-                fail: 'Errore'
+                fail: 'Errore',
+                feedbackButton: 'Invia feedback',
+                fbCategory: 'Categoria:',
+                fbCode: 'Codice (opzionale):',
+                fbMessage: 'Messaggio:',
+                fbSubmit: 'Invia',
+                fbCancel: 'Annulla',
+                feedbackTitle: 'Invia feedback',
+                fbContext: 'Contesto',
+                fbThanks: 'Grazie per il feedback!'
             }
         };
         let examplesData = [];
@@ -657,6 +721,22 @@
             document.getElementById('spinner').textContent = t.loading;
             const qLink = document.getElementById('qualityLink');
             if(qLink) qLink.textContent = t.qualityLink;
+            const fbBtn = document.getElementById('feedbackButton');
+            if(fbBtn) fbBtn.textContent = t.feedbackButton;
+            const fbCat = document.getElementById('fbCategoryLabel');
+            if(fbCat) fbCat.textContent = t.fbCategory;
+            const fbCode = document.getElementById('fbCodeLabel');
+            if(fbCode) fbCode.textContent = t.fbCode;
+            const fbMsg = document.getElementById('fbMessageLabel');
+            if(fbMsg) fbMsg.textContent = t.fbMessage;
+            const fbSub = document.getElementById('fbSubmitButton');
+            if(fbSub) fbSub.textContent = t.fbSubmit;
+            const fbCan = document.getElementById('fbCancelButton');
+            if(fbCan) fbCan.textContent = t.fbCancel;
+            const fbTitle = document.getElementById('feedbackModalTitle');
+            if(fbTitle) fbTitle.textContent = t.feedbackTitle;
+            const fbCtx = document.getElementById('fbContextLabel');
+            if(fbCtx) fbCtx.textContent = t.fbContext;
             const out = document.getElementById('output');
             if(out){
                 const prev = translations[prevLang] || translations['de'];
@@ -691,7 +771,74 @@
             if(selB) selB.selectedIndex=0;
         }
         document.getElementById('languageSelect').addEventListener('change',e=>applyLanguage(e.target.value));
+        document.getElementById('feedbackButton').addEventListener('click',toggleFeedback);
+        document.getElementById('fbSubmitButton').addEventListener('click',sendFeedback);
+        document.getElementById('fbCancelButton').addEventListener('click',toggleFeedback);
+        document.getElementById('feedbackModalClose').addEventListener('click',toggleFeedback);
+        document.getElementById('feedbackModalOverlay').addEventListener('click',e=>{if(e.target.id==='feedbackModalOverlay'&&!isResizing)toggleFeedback();});
         document.addEventListener('DOMContentLoaded',initLanguage);
+
+        function toggleFeedback(){
+            const overlay = document.getElementById('feedbackModalOverlay');
+            if(!overlay) return;
+            if(overlay.style.display === 'none' || overlay.style.display===''){
+                updateFeedbackContext();
+                overlay.style.display='block';
+                makeModalDraggable(document.getElementById('feedbackModal'));
+            }else{
+                overlay.style.display='none';
+            }
+        }
+
+        function updateFeedbackContext(){
+            const ctx = {
+                url: window.location.href,
+                userAgent: navigator.userAgent,
+                screen: `${window.screen.width}x${window.screen.height}`,
+                inputs: {
+                    userInput: document.getElementById('userInput').value,
+                    icdInput: document.getElementById('icdInput').value,
+                    gtinInput: document.getElementById('gtinInput').value,
+                    useIcd: document.getElementById('useIcdCheckbox').checked
+                }
+            };
+            document.getElementById('fbContextPre').textContent = JSON.stringify(ctx, null, 2);
+        }
+
+        async function sendFeedback(){
+            const status = document.getElementById('feedbackStatus');
+            if(status) status.textContent = '';
+            const payload = {
+                category: document.getElementById('feedbackCategory').value,
+                code: document.getElementById('feedbackCode').value,
+                message: document.getElementById('feedbackText').value,
+                user_input: (typeof lastUserInput !== 'undefined' ? lastUserInput : document.getElementById('userInput').value),
+                pauschale: (typeof selectedPauschaleDetails === 'object' && selectedPauschaleDetails ? selectedPauschaleDetails.Pauschale : null),
+                einzelleistungen: Array.isArray(lastBackendResponse?.abrechnung?.leistungen) ? lastBackendResponse.abrechnung.leistungen : [],
+                begruendung_llm1: lastBackendResponse?.llm_ergebnis_stufe1?.begruendung_llm || '',
+                begruendung_llm2: JSON.stringify(lastBackendResponse?.llm_ergebnis_stufe2 || {}),
+                context: JSON.parse(document.getElementById('fbContextPre').textContent || '{}')
+            };
+            try{
+                const resp = await fetch('/api/submit-feedback', {
+                    method: 'POST',
+                    headers: {'Content-Type':'application/json'},
+                    body: JSON.stringify(payload)
+                });
+                let data = {};
+                try { data = await resp.json(); } catch(_) {}
+                if(resp.ok){
+                    if(status) status.textContent = translations[currentLang].fbThanks;
+                    document.getElementById('feedbackText').value = '';
+                    document.getElementById('feedbackModalOverlay').style.display='none';
+                } else {
+                    const msg = data.error || translations[currentLang].fail;
+                    if(status) status.textContent = msg;
+                }
+            }catch(e){
+                if(status) status.textContent = translations[currentLang].fail;
+            }
+        }
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -398,13 +398,15 @@
         .top-info {
             position: absolute;
             top: 10px;
+            left: 10px;
             right: 10px;
             display: flex;
             align-items: center;
             gap: 10px;
-            font-size: 0.75em;
+            font-size: 0.85em;
             color: #555;
         }
+        .top-info button { margin-top: 0; }
         #qualityLink { color: var(--primary); text-decoration:none; }
         #qualityLink:hover { text-decoration: underline; }
         @keyframes spin { to { transform: rotate(360deg); } }
@@ -456,6 +458,7 @@
     </div>
 
     <div class="top-info">
+        <button id="feedbackButton" type="button">Feedback geben</button>
         <div class="language-select">
             <label id="langLabel" for="languageSelect">Sprache:</label>
             <select id="languageSelect">
@@ -464,12 +467,12 @@
                 <option value="it">Italiano</option>
             </select>
         </div>
+        <a id="qualityLink" href="quality.html">Qualitätskontrolle</a>
         <div class="version-info">
             V2.1, Arnet Konsilium,
             <a href="https://www.arkons.ch/" target="_blank">https://www.arkons.ch/</a>,
             2025
         </div>
-        <a id="qualityLink" href="quality.html">Qualitätskontrolle</a>
     </div>
 
     <h1 id="mainHeader">Neuer Arzttarif Schweiz: TARDOC und Pauschalen</h1>
@@ -507,7 +510,6 @@
         <!-- Content will be inserted by JavaScript -->
     </div>
 
-    <button id="feedbackButton" type="button">Feedback geben</button>
     <div id="feedbackModalOverlay" class="info-modal-overlay" style="display:none;">
         <div id="feedbackModal" class="info-modal" style="width:400px;height:auto;top:20vh;left:calc(50% - 200px);">
             <button id="feedbackModalClose" class="modal-close">&times;</button>
@@ -795,11 +797,15 @@
                 url: window.location.href,
                 userAgent: navigator.userAgent,
                 screen: `${window.screen.width}x${window.screen.height}`,
-                inputs: {
+                form: {
                     userInput: document.getElementById('userInput').value,
                     icdInput: document.getElementById('icdInput').value,
                     gtinInput: document.getElementById('gtinInput').value,
-                    useIcd: document.getElementById('useIcdCheckbox').checked
+                    useIcd: document.getElementById('useIcdCheckbox').checked,
+                    pauschale: (typeof selectedPauschaleDetails === 'object' && selectedPauschaleDetails ? selectedPauschaleDetails.Pauschale : null),
+                    einzelleistungen: Array.isArray(lastBackendResponse?.abrechnung?.leistungen) ? lastBackendResponse.abrechnung.leistungen : [],
+                    begruendung_llm1: lastBackendResponse?.llm_ergebnis_stufe1?.begruendung_llm || '',
+                    begruendung_llm2: lastBackendResponse?.llm_ergebnis_stufe2 || {}
                 }
             };
             document.getElementById('fbContextPre').textContent = JSON.stringify(ctx, null, 2);

--- a/index.html
+++ b/index.html
@@ -38,6 +38,7 @@
             border-bottom: 2px solid var(--primary);
             padding-bottom: 5px;
         }
+        #mainHeader { margin-top: 60px; }
         label {
             display: block;
             margin-bottom: 5px;
@@ -398,8 +399,9 @@
         .top-info {
             position: absolute;
             top: 10px;
-            left: 10px;
-            right: 10px;
+            left: 0;
+            right: 0;
+            padding: 0 10px;
             display: flex;
             align-items: center;
             gap: 10px;

--- a/index.html
+++ b/index.html
@@ -399,14 +399,17 @@
         .top-info {
             position: absolute;
             top: 10px;
-            left: 0;
-            right: 0;
+            left: 50%;
+            transform: translateX(-50%);
+            width: 100%;
+            max-width: 1600px;
             padding: 0 10px;
             display: flex;
             align-items: center;
             gap: 10px;
             font-size: 0.85em;
             color: #555;
+            box-sizing: border-box;
         }
         .top-info button { margin-top: 0; }
         #qualityLink { color: var(--primary); text-decoration:none; }


### PR DESCRIPTION
## Summary
- ignore `feedback_local.json` artifacts
- test local feedback storage via `/api/submit-feedback`
- capture UTC timestamp correctly when storing feedback
- document the new feedback feature in the README
- document GitHub token setup and expiration in INSTALLATION
- enhance feedback module with modal form, context capture, and local storage fallback

## Testing
- `pytest -q`
- `python run_quality_tests.py` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_687a9a9e03bc83239fc57e87d2b039a4